### PR TITLE
Correct Mac/Java9 check in VNCScreen

### DIFF
--- a/API/src/main/java/org/sikuli/vnc/VNCScreen.java
+++ b/API/src/main/java/org/sikuli/vnc/VNCScreen.java
@@ -38,19 +38,17 @@ public class VNCScreen extends Region implements IScreen, Closeable {
 //    private static boolean loadProviderFromProperty() {
 
   public static VNCScreen start(String theIP, int thePort, String password, int cTimeout, int timeout) throws IOException {
-    VNCScreen scr = null;
-    if (!(RunTime.get().runningMac && RunTime.get().isJava9("VNCScreen not yet working on Mac"))) {
-      scr = new VNCScreen(VNCClient.connect(theIP, thePort, password, true));
-      screens.put(scr, scr.client);
+    if (RunTime.get().runningMac && RunTime.get().isJava9("VNCScreen not yet working on Mac")) {
+      throw new IOException("VNCScreen does not working yet under Java 9 on Mac");
     }
+
+    VNCScreen scr = new VNCScreen(VNCClient.connect(theIP, thePort, password, true));
+    screens.put(scr, scr.client);
     return scr;
   }
 
   public static VNCScreen start(String theIP, int thePort, int cTimeout, int timeout) throws IOException {
     return start(theIP, thePort, null, cTimeout, timeout);
-//    VNCScreen scr = new VNCScreen(VNCClient.connect(theIP, thePort, null, true));
-//    screens.put(scr, scr.client);
-//    return scr;
   }
 
   public static VNCScreen start(String theIP, int thePort) throws IOException {


### PR DESCRIPTION
In 1.1.2 the check in question is broken. This makes VNC pretty much unusable on anything except Mac.

I've reorganised the check here a bit to make it clearer and throw an exception instead of silently returning `null`.