### PR TITLE
Really set PageSegMode

### DIFF
--- a/API/src/main/java/org/sikuli/script/TextRecognizer.java
+++ b/API/src/main/java/org/sikuli/script/TextRecognizer.java
@@ -141,7 +141,7 @@ public class TextRecognizer {
     }
     if (isValid()) {
       this.psm = psm;
-      tess.setOcrEngineMode(this.psm);
+      tess.setPageSegMode(this.psm);
     }
     return this;
   }


### PR DESCRIPTION
This method was calling the wrong method of the Tesseract1 object. Caused invalid memory access when doing a text search afterwards.