### PR TITLE
Propagate exitCode of runner process to main script

### DIFF
--- a/IDE/src/main/java/org/sikuli/ide/Sikulix.java
+++ b/IDE/src/main/java/org/sikuli/ide/Sikulix.java
@@ -168,6 +168,7 @@ public class Sikulix {
     cmd.addAll(Arrays.asList(args));
     int exitValue = ProcessRunner.detach(cmd);
     log(1, "terminating: returned: %d", exitValue);
+    System.exit(exitValue);
   }
 
   private static void log(int level, String msg, Object... args) {


### PR DESCRIPTION
The exit code of the inner process started from ProcessRunner was not visible from the caller of the Sikulix jar.

"java -jar sikulixide.jar -r test.sikuli" always had the exit code 0.