### PR TITLE
Detect current keyboard layout and use it for type (on Windows)

### DIFF
--- a/API/src/main/java/org/sikuli/basics/Settings.java
+++ b/API/src/main/java/org/sikuli/basics/Settings.java
@@ -57,6 +57,7 @@ public class Settings {
   public static double MinSimilarity = 0.7;
   public static float AlwaysResize = 0;
   public static int DefaultPadding = 50;
+  public static boolean AutoDetectKeyboardLayout = true;  
 
   public static boolean CheckLastSeen = true;
   public static float CheckLastSeenSimilar = 0.95f;

--- a/API/src/main/java/org/sikuli/natives/SXUser32.java
+++ b/API/src/main/java/org/sikuli/natives/SXUser32.java
@@ -2,6 +2,7 @@ package org.sikuli.natives;
 
 import com.sun.jna.Native;
 import com.sun.jna.platform.win32.User32;
+import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.win32.W32APIOptions;
 
 public interface SXUser32 extends User32 {
@@ -9,5 +10,14 @@ public interface SXUser32 extends User32 {
   SXUser32 INSTANCE = (SXUser32) Native.loadLibrary("user32", SXUser32.class, W32APIOptions.DEFAULT_OPTIONS);
 
   short GetKeyState(int vKey);
+  
+  int GetKeyboardLayout(int dwLayout);
+  
+  int MapVirtualKeyExW (int uCode, int nMapType, int dwhkl);
+
+  boolean GetKeyboardState(byte[] lpKeyState);
+
+  int ToUnicodeEx(int wVirtKey, int wScanCode, byte[] lpKeyState, char[] pwszBuff, int cchBuff, int wFlags, int dwhkl);
+  
 }
 

--- a/API/src/main/java/org/sikuli/natives/SXUser32.java
+++ b/API/src/main/java/org/sikuli/natives/SXUser32.java
@@ -2,7 +2,6 @@ package org.sikuli.natives;
 
 import com.sun.jna.Native;
 import com.sun.jna.platform.win32.User32;
-import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.win32.W32APIOptions;
 
 public interface SXUser32 extends User32 {

--- a/API/src/main/java/org/sikuli/script/Key.java
+++ b/API/src/main/java/org/sikuli/script/Key.java
@@ -3,14 +3,14 @@
  */
 package org.sikuli.script;
 
-import org.sikuli.basics.HotkeyManager;
-import org.sikuli.basics.HotkeyListener;
-import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
+
 import org.sikuli.basics.Debug;
+import org.sikuli.basics.HotkeyListener;
+import org.sikuli.basics.HotkeyManager;
 import org.sikuli.basics.Settings;
 import org.sikuli.natives.WinUtil;
 
@@ -22,7 +22,7 @@ import org.sikuli.natives.WinUtil;
  * for details consult the docs
  */
 public class Key {
-
+  
   /**
    * add a hotkey and listener
    * @param key respective key specifier according class Key
@@ -64,7 +64,7 @@ public class Key {
   public static boolean removeHotkey(char key, int modifiers) {
     return HotkeyManager.getInstance().removeHotkey(key, modifiers);
   }
-
+      
   static String[] keyVK = new String[] {
   //<editor-fold defaultstate="collapsed" desc="VK_xxx constant names and values Java 7">
     "VK_0","48",
@@ -495,8 +495,8 @@ public class Key {
 
   /**
    * Convert Sikuli Key to Java virtual key code
-	 * @param key as String
-	 * @return the Java KeyCodes
+   * @param key as String
+   * @return the Java KeyCodes
    */
   public static int[] toJavaKeyCode(String key) {
     if (key.length() > 0) {
@@ -507,188 +507,11 @@ public class Key {
 
   /**
    * Convert Sikuli Key to Java virtual key code
-	 * @param key as Character
-	 * @return the Java KeyCodes
+   * @param key as Character
+   * @return the Java KeyCodes
    */
   public static int[] toJavaKeyCode(char key) {
-    switch (key) {
-//Lowercase
-      case 'a': return new int[]{KeyEvent.VK_A};
-      case 'b': return new int[]{KeyEvent.VK_B};
-      case 'c': return new int[]{KeyEvent.VK_C};
-      case 'd': return new int[]{KeyEvent.VK_D};
-      case 'e': return new int[]{KeyEvent.VK_E};
-      case 'f': return new int[]{KeyEvent.VK_F};
-      case 'g': return new int[]{KeyEvent.VK_G};
-      case 'h': return new int[]{KeyEvent.VK_H};
-      case 'i': return new int[]{KeyEvent.VK_I};
-      case 'j': return new int[]{KeyEvent.VK_J};
-      case 'k': return new int[]{KeyEvent.VK_K};
-      case 'l': return new int[]{KeyEvent.VK_L};
-      case 'm': return new int[]{KeyEvent.VK_M};
-      case 'n': return new int[]{KeyEvent.VK_N};
-      case 'o': return new int[]{KeyEvent.VK_O};
-      case 'p': return new int[]{KeyEvent.VK_P};
-      case 'q': return new int[]{KeyEvent.VK_Q};
-      case 'r': return new int[]{KeyEvent.VK_R};
-      case 's': return new int[]{KeyEvent.VK_S};
-      case 't': return new int[]{KeyEvent.VK_T};
-      case 'u': return new int[]{KeyEvent.VK_U};
-      case 'v': return new int[]{KeyEvent.VK_V};
-      case 'w': return new int[]{KeyEvent.VK_W};
-      case 'x': return new int[]{KeyEvent.VK_X};
-      case 'y': return new int[]{KeyEvent.VK_Y};
-      case 'z': return new int[]{KeyEvent.VK_Z};
-//Uppercase
-      case 'A': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_A};
-      case 'B': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_B};
-      case 'C': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_C};
-      case 'D': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_D};
-      case 'E': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_E};
-      case 'F': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_F};
-      case 'G': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_G};
-      case 'H': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_H};
-      case 'I': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_I};
-      case 'J': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_J};
-      case 'K': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_K};
-      case 'L': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_L};
-      case 'M': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_M};
-      case 'N': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_N};
-      case 'O': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_O};
-      case 'P': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_P};
-      case 'Q': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_Q};
-      case 'R': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_R};
-      case 'S': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_S};
-      case 'T': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_T};
-      case 'U': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_U};
-      case 'V': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_V};
-      case 'W': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_W};
-      case 'X': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_X};
-      case 'Y': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_Y};
-      case 'Z': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_Z};
-//Row 3 (below function keys)
-//      case '§': return new int[]{192}; //not producable
-      case '1': return new int[]{KeyEvent.VK_1};
-      case '!': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_1};
-      case '2': return new int[]{KeyEvent.VK_2};
-      case '@': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_2};
-      case '3': return new int[]{KeyEvent.VK_3};
-      case '#': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_3};
-      case '4': return new int[]{KeyEvent.VK_4};
-      case '$': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_4};
-      case '5': return new int[]{KeyEvent.VK_5};
-      case '%': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_5};
-      case '6': return new int[]{KeyEvent.VK_6};
-      case '^': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_6};
-      case '7': return new int[]{KeyEvent.VK_7};
-      case '&': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_7};
-      case '8': return new int[]{KeyEvent.VK_8};
-      case '*': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_8};
-      case '9': return new int[]{KeyEvent.VK_9};
-      case '(': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_9};
-      case '0': return new int[]{KeyEvent.VK_0};
-      case ')': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_0};
-      case '-': return new int[]{KeyEvent.VK_MINUS};
-      case '_': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_MINUS};
-      case '=': return new int[]{KeyEvent.VK_EQUALS};
-      case '+': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_EQUALS};
-//Row 2
-// q w e r t y u i o p
-      case '[': return new int[]{KeyEvent.VK_OPEN_BRACKET};
-      case '{': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_OPEN_BRACKET};
-      case ']': return new int[]{KeyEvent.VK_CLOSE_BRACKET};
-      case '}': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_CLOSE_BRACKET};
-//Row 1
-// a s d f g h j k l
-      case ';': return new int[]{KeyEvent.VK_SEMICOLON};
-      case ':': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_SEMICOLON};
-      case '\'': return new int[]{KeyEvent.VK_QUOTE};
-      case '"': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_QUOTE};
-      case '\\': return new int[]{KeyEvent.VK_BACK_SLASH};
-      case '|': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_BACK_SLASH};
-//RETURN, BACKSPACE, TAB
-      case '\b': return new int[]{KeyEvent.VK_BACK_SPACE};
-      case '\t': return new int[]{KeyEvent.VK_TAB};
-      case '\r': return new int[]{KeyEvent.VK_ENTER};
-      case '\n': return new int[]{KeyEvent.VK_ENTER};
-//SPACE
-      case ' ': return new int[]{KeyEvent.VK_SPACE};
-//Row 0 (first above SPACE)
-      case '`': return new int[]{KeyEvent.VK_BACK_QUOTE};
-      case '~': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_BACK_QUOTE};
-// z x c v b n m
-      case ',': return new int[]{KeyEvent.VK_COMMA};
-      case '<': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_COMMA};
-      case '.': return new int[]{KeyEvent.VK_PERIOD};
-      case '>': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_PERIOD};
-      case '/': return new int[]{KeyEvent.VK_SLASH};
-      case '?': return new int[]{KeyEvent.VK_SHIFT, KeyEvent.VK_SLASH};
-//Modifier
-      case Key.C_SHIFT: return new int[]{KeyEvent.VK_SHIFT};
-      case Key.C_CTRL:  return new int[]{KeyEvent.VK_CONTROL};
-      case Key.C_ALT:   return new int[]{KeyEvent.VK_ALT};
-      case Key.C_META:  return new int[]{KeyEvent.VK_META};
-//Cursor movement
-      case Key.C_UP:     return new int[]{KeyEvent.VK_UP};
-      case Key.C_RIGHT:     return new int[]{KeyEvent.VK_RIGHT};
-      case Key.C_DOWN:      return new int[]{KeyEvent.VK_DOWN};
-      case Key.C_LEFT:      return new int[]{KeyEvent.VK_LEFT};
-      case Key.C_PAGE_UP:   return new int[]{KeyEvent.VK_PAGE_UP};
-      case Key.C_PAGE_DOWN: return new int[]{KeyEvent.VK_PAGE_DOWN};
-      case Key.C_END:       return new int[]{KeyEvent.VK_END};
-      case Key.C_HOME:      return new int[]{KeyEvent.VK_HOME};
-      case Key.C_DELETE:    return new int[]{KeyEvent.VK_DELETE};
-//Function keys
-      case Key.C_ESC: return new int[]{KeyEvent.VK_ESCAPE};
-      case Key.C_F1:  return new int[]{KeyEvent.VK_F1};
-      case Key.C_F2:  return new int[]{KeyEvent.VK_F2};
-      case Key.C_F3:  return new int[]{KeyEvent.VK_F3};
-      case Key.C_F4:  return new int[]{KeyEvent.VK_F4};
-      case Key.C_F5:  return new int[]{KeyEvent.VK_F5};
-      case Key.C_F6:  return new int[]{KeyEvent.VK_F6};
-      case Key.C_F7:  return new int[]{KeyEvent.VK_F7};
-      case Key.C_F8:  return new int[]{KeyEvent.VK_F8};
-      case Key.C_F9:  return new int[]{KeyEvent.VK_F9};
-      case Key.C_F10: return new int[]{KeyEvent.VK_F10};
-      case Key.C_F11: return new int[]{KeyEvent.VK_F11};
-      case Key.C_F12: return new int[]{KeyEvent.VK_F12};
-      case Key.C_F13: return new int[]{KeyEvent.VK_F13};
-      case Key.C_F14: return new int[]{KeyEvent.VK_F14};
-      case Key.C_F15: return new int[]{KeyEvent.VK_F15};
-//Toggling kezs
-      case Key.C_SCROLL_LOCK: return new int[]{KeyEvent.VK_SCROLL_LOCK};
-      case Key.C_NUM_LOCK:    return new int[]{KeyEvent.VK_NUM_LOCK};
-      case Key.C_CAPS_LOCK:   return new int[]{KeyEvent.VK_CAPS_LOCK};
-      case Key.C_INSERT:      return new int[]{KeyEvent.VK_INSERT};
-//Windows special
-      case Key.C_PAUSE:       return new int[]{KeyEvent.VK_PAUSE};
-      case Key.C_PRINTSCREEN: return new int[]{KeyEvent.VK_PRINTSCREEN};
-//Num pad
-      case Key.C_NUM0: return new int[]{KeyEvent.VK_NUMPAD0};
-      case Key.C_NUM1: return new int[]{KeyEvent.VK_NUMPAD1};
-      case Key.C_NUM2: return new int[]{KeyEvent.VK_NUMPAD2};
-      case Key.C_NUM3: return new int[]{KeyEvent.VK_NUMPAD3};
-      case Key.C_NUM4: return new int[]{KeyEvent.VK_NUMPAD4};
-      case Key.C_NUM5: return new int[]{KeyEvent.VK_NUMPAD5};
-      case Key.C_NUM6: return new int[]{KeyEvent.VK_NUMPAD6};
-      case Key.C_NUM7: return new int[]{KeyEvent.VK_NUMPAD7};
-      case Key.C_NUM8: return new int[]{KeyEvent.VK_NUMPAD8};
-      case Key.C_NUM9: return new int[]{KeyEvent.VK_NUMPAD9};
-//Num pad special
-      case Key.C_SEPARATOR: return new int[]{KeyEvent.VK_SEPARATOR};
-      case Key.C_ADD:       return new int[]{KeyEvent.VK_ADD};
-      case Key.C_MINUS:     return new int[]{KeyEvent.VK_SUBTRACT};
-      case Key.C_MULTIPLY:  return new int[]{KeyEvent.VK_MULTIPLY};
-      case Key.C_DIVIDE:    return new int[]{KeyEvent.VK_DIVIDE};
-      case Key.C_DECIMAL:   return new int[]{KeyEvent.VK_DECIMAL};
-      case Key.C_CONTEXT:   return new int[]{KeyEvent.VK_CONTEXT_MENU};
-      case Key.C_WIN:   return new int[]{KeyEvent.VK_WINDOWS};
-//hack: alternative tab in GUI
-      case Key.C_NEXT:   return new int[]{-KeyEvent.VK_TAB};
-
-      default:
-        throw new IllegalArgumentException("Key: Not supported character: " + key);
-    }
+    return KeyboardLayout.toJavaKeyCode(key);
   }
 
   /**
@@ -793,7 +616,7 @@ public class Key {
     }
     return modNew;
   }
-
+  
   /**
    * get the lock state of the given key
    *
@@ -825,11 +648,11 @@ public class Key {
     return (state % 2) > 0;
   }
 
-	/**
-	 * HotKey modifier to be used with Sikuli's HotKey feature
-	 * @return META(CMD) on Mac, CTRL otherwise
-	 */
-	public static int getHotkeyModifier() {
+  /**
+   * HotKey modifier to be used with Sikuli's HotKey feature
+   * @return META(CMD) on Mac, CTRL otherwise
+   */
+  public static int getHotkeyModifier() {
     if (Settings.isMac()) {
       return KeyEvent.VK_META;
     } else {
@@ -844,158 +667,158 @@ public class Key {
    * INTERNAL USE ONLY
    * create an alternate keycode table for a non-US keyboard
    */
-//	public static void keyBoardSetup() {
-//		Map<Character, Integer[]> keyLocal = new HashMap<Character, Integer[]>();
-//		String[] keyXX = new String[]{"", "", "", "",};
-//		String keysx = Key.keyboardUS;
+//  public static void keyBoardSetup() {
+//    Map<Character, Integer[]> keyLocal = new HashMap<Character, Integer[]>();
+//    String[] keyXX = new String[]{"", "", "", "",};
+//    String keysx = Key.keyboardUS;
 //
-//		try {
-//			Screen s = new Screen(0);
-//			ImagePath.add("org.sikuli.basics.SikuliX/Images");
+//    try {
+//      Screen s = new Screen(0);
+//      ImagePath.add("org.sikuli.basics.SikuliX/Images");
 //
-//			ShowKeyBoardSetupWindow win = new ShowKeyBoardSetupWindow();
-//			win.start();
-//			s.wait(3.0F);
+//      ShowKeyBoardSetupWindow win = new ShowKeyBoardSetupWindow();
+//      win.start();
+//      s.wait(3.0F);
 //
-//			Location btnOK = s.find("SikuliLogo").getCenter();
-//			Location txtArea = btnOK.offset(0, 400);
-//			s.click(txtArea);
-//			s.wait(1.0F);
-//			String[] mods = new String[]{"", "S", "A", "SA"};
-//			Debug.setDebugLevel(0);
-//			for (String modx : mods) {
-//				s.paste((modx.isEmpty() ? "NO" : modx) + " modifier" + "\n");
-//				if (!modx.isEmpty()) {
-//					if (modx.length() == 1) {
-//						modx = "#" + modx + ".";
-//					} else if (modx.length() == 2) {
-//						modx = "#" + modx.substring(0, 1) + ".#" + modx.substring(1, 2) + ".";
-//					} else {
-//						break;
-//					}
-//				}
-//				String c;
-//				for (int n = 0; n < keysx.length(); n++) {
-//					c = "" + keysx.charAt(n);
-//					s.paste(c);
-//					s.type(" ");
-//					if (Mouse.hasMoved()) {
-//						s.click(txtArea);
-//						s.wait(0.3F);
-//					}
-//					s.write(String.format("%s%s ", modx, c));
-//					if ("=".equals(c) || "]".equals(c) || "\\".equals(c)) {
-//						s.paste("\n");
-//					}
-//				}
-//				s.paste("\n");
-//				s.type(Key.ENTER);
-//			}
-//			Debug.setDebugLevel(3);
-//			s.click(btnOK);
-//		} catch (FindFailed e) {
-//			Debug.error("KeyBoardSetup: Does not work - getting FindFailed");
-//			return;
-//		}
-//		while (true) {
-//			try {
-//				Thread.sleep(1000);
-//			} catch (InterruptedException ex) {
-//			}
-//			Debug.log(3, "waiting for result\n" + result[0]);
-//			if (!result[0].isEmpty()) {
-//				break;
-//			}
-//		}
-//		String[] keyNewx = result[0].split("\n");
-//		String keysNew;
-//		String mod;
-//		int nKDE = 0;
-//		for (int n = 0; n < keyNewx.length; n += 6) {
-//			mod = keyNewx[n].substring(0, 2);
-//			keysNew = keyNewx[n + 1] + keyNewx[n + 2] + keyNewx[n + 3] + keyNewx[n + 4];
-//			keyXX[nKDE] = mod + ": " + keysNew;
-//			Debug.log(3, "%s", keyXX[nKDE]);
-//			nKDE++;
-//		}
-//		String kSet;
-//		int offset = 4;
-//		char keyOld, keyNew;
-//		int[] codeA;
-//		String codeS;
-//		String modText;
-//		int nOld;
-//		for (int n = 0; n < 4; n++) {
-//			kSet = keyXX[n].substring(4);
-//			mod = keyXX[n].substring(0, 2);
-//			modText = "";
-//			if ("S ".equals(mod)) {
-//				modText = "SHIFT ";
-//			} else if ("A ".equals(mod)) {
-//				modText = "ALT ";
-//			} else if ("SA".equals(mod)) {
-//				modText = "SHIFT ALT ";
-//			}
-//			Debug.log(3, mod + "\n" + kSet);
-//			nOld = 0;
-//			for (int i = 0; i < kSet.length(); i++) {
-//				if (i + 3 > kSet.length()) {
-//					break;
-//				}
-//				if (!" ".equals("" + kSet.charAt(i + 3))) {
-//					offset = 3;
-//				}
-//				keyOld = kSet.charAt(i);
-//				keyNew = kSet.charAt(i + 2);
-//				Integer[] codeI = new Integer[]{-1, -1, -1};
-//				try {
-//					codeA = Key.toJavaKeyCode(keyNew);
-//					codeS = "";
-//					for (int iK : codeA) {
-//						codeS += KeyEvent.getKeyText(iK) + " ";
-//					}
-//					if (codeA.length == 1) {
-//						codeI[2] = codeA[0];
-//					} else if (codeA.length == 2) {
-//						codeI[2] = codeA[1];
-//						codeI[0] = codeA[0];
-//					} else if (codeA.length == 3) {
-//						codeI[2] = codeA[2];
-//						codeI[0] = codeA[0];
-//						codeI[1] = codeA[1];
-//					}
-//				} catch (Exception e) {
-//					codeS = "UNKNOWN ";
-//					codeI[2] = Key.toJavaKeyCode(keysx.charAt(nOld))[0];
-//					codeS += modText + KeyEvent.getKeyText(codeI[2]);
-//					for (int ik = 0; ik < 2; ik++) {
-//						if (mod.charAt(ik) == 'S') {
-//							codeI[ik] = KeyEvent.VK_SHIFT;
-//						} else if (mod.charAt(ik) == 'A') {
-//							codeI[ik] = KeyEvent.VK_ALT;
-//						}
-//					}
-//				}
-//				if (keyLocal.get(keyNew) == null) {
-//					keyLocal.put(keyNew, codeI);
-//				}
-//				Debug.log(3, "%s %c %c %s", mod, keyOld, keyNew, codeS);
-//				i += offset - 1;
-//				offset = 4;
-//				nOld += 1;
-//			}
-//		}
+//      Location btnOK = s.find("SikuliLogo").getCenter();
+//      Location txtArea = btnOK.offset(0, 400);
+//      s.click(txtArea);
+//      s.wait(1.0F);
+//      String[] mods = new String[]{"", "S", "A", "SA"};
+//      Debug.setDebugLevel(0);
+//      for (String modx : mods) {
+//        s.paste((modx.isEmpty() ? "NO" : modx) + " modifier" + "\n");
+//        if (!modx.isEmpty()) {
+//          if (modx.length() == 1) {
+//            modx = "#" + modx + ".";
+//          } else if (modx.length() == 2) {
+//            modx = "#" + modx.substring(0, 1) + ".#" + modx.substring(1, 2) + ".";
+//          } else {
+//            break;
+//          }
+//        }
+//        String c;
+//        for (int n = 0; n < keysx.length(); n++) {
+//          c = "" + keysx.charAt(n);
+//          s.paste(c);
+//          s.type(" ");
+//          if (Mouse.hasMoved()) {
+//            s.click(txtArea);
+//            s.wait(0.3F);
+//          }
+//          s.write(String.format("%s%s ", modx, c));
+//          if ("=".equals(c) || "]".equals(c) || "\\".equals(c)) {
+//            s.paste("\n");
+//          }
+//        }
+//        s.paste("\n");
+//        s.type(Key.ENTER);
+//      }
+//      Debug.setDebugLevel(3);
+//      s.click(btnOK);
+//    } catch (FindFailed e) {
+//      Debug.error("KeyBoardSetup: Does not work - getting FindFailed");
+//      return;
+//    }
+//    while (true) {
+//      try {
+//        Thread.sleep(1000);
+//      } catch (InterruptedException ex) {
+//      }
+//      Debug.log(3, "waiting for result\n" + result[0]);
+//      if (!result[0].isEmpty()) {
+//        break;
+//      }
+//    }
+//    String[] keyNewx = result[0].split("\n");
+//    String keysNew;
+//    String mod;
+//    int nKDE = 0;
+//    for (int n = 0; n < keyNewx.length; n += 6) {
+//      mod = keyNewx[n].substring(0, 2);
+//      keysNew = keyNewx[n + 1] + keyNewx[n + 2] + keyNewx[n + 3] + keyNewx[n + 4];
+//      keyXX[nKDE] = mod + ": " + keysNew;
+//      Debug.log(3, "%s", keyXX[nKDE]);
+//      nKDE++;
+//    }
+//    String kSet;
+//    int offset = 4;
+//    char keyOld, keyNew;
+//    int[] codeA;
+//    String codeS;
+//    String modText;
+//    int nOld;
+//    for (int n = 0; n < 4; n++) {
+//      kSet = keyXX[n].substring(4);
+//      mod = keyXX[n].substring(0, 2);
+//      modText = "";
+//      if ("S ".equals(mod)) {
+//        modText = "SHIFT ";
+//      } else if ("A ".equals(mod)) {
+//        modText = "ALT ";
+//      } else if ("SA".equals(mod)) {
+//        modText = "SHIFT ALT ";
+//      }
+//      Debug.log(3, mod + "\n" + kSet);
+//      nOld = 0;
+//      for (int i = 0; i < kSet.length(); i++) {
+//        if (i + 3 > kSet.length()) {
+//          break;
+//        }
+//        if (!" ".equals("" + kSet.charAt(i + 3))) {
+//          offset = 3;
+//        }
+//        keyOld = kSet.charAt(i);
+//        keyNew = kSet.charAt(i + 2);
+//        Integer[] codeI = new Integer[]{-1, -1, -1};
+//        try {
+//          codeA = Key.toJavaKeyCode(keyNew);
+//          codeS = "";
+//          for (int iK : codeA) {
+//            codeS += KeyEvent.getKeyText(iK) + " ";
+//          }
+//          if (codeA.length == 1) {
+//            codeI[2] = codeA[0];
+//          } else if (codeA.length == 2) {
+//            codeI[2] = codeA[1];
+//            codeI[0] = codeA[0];
+//          } else if (codeA.length == 3) {
+//            codeI[2] = codeA[2];
+//            codeI[0] = codeA[0];
+//            codeI[1] = codeA[1];
+//          }
+//        } catch (Exception e) {
+//          codeS = "UNKNOWN ";
+//          codeI[2] = Key.toJavaKeyCode(keysx.charAt(nOld))[0];
+//          codeS += modText + KeyEvent.getKeyText(codeI[2]);
+//          for (int ik = 0; ik < 2; ik++) {
+//            if (mod.charAt(ik) == 'S') {
+//              codeI[ik] = KeyEvent.VK_SHIFT;
+//            } else if (mod.charAt(ik) == 'A') {
+//              codeI[ik] = KeyEvent.VK_ALT;
+//            }
+//          }
+//        }
+//        if (keyLocal.get(keyNew) == null) {
+//          keyLocal.put(keyNew, codeI);
+//        }
+//        Debug.log(3, "%s %c %c %s", mod, keyOld, keyNew, codeS);
+//        i += offset - 1;
+//        offset = 4;
+//        nOld += 1;
+//      }
+//    }
 //
-//		Debug.log(3, "--------------- keyLocal");
-//		Integer[] codeI;
-//		for (Character kc : keyLocal.keySet()) {
-//			codeI = keyLocal.get(kc);
-//			Debug.log(3, "%c %s %s %s", kc.charValue(),
-//							(codeI[0] == -1 ? "" : KeyEvent.getKeyText(codeI[0])),
-//							(codeI[1] == -1 ? "" : KeyEvent.getKeyText(codeI[1])),
-//							(codeI[2] == -1 ? "" : KeyEvent.getKeyText(codeI[2])));
-//		}
-//	}
+//    Debug.log(3, "--------------- keyLocal");
+//    Integer[] codeI;
+//    for (Character kc : keyLocal.keySet()) {
+//      codeI = keyLocal.get(kc);
+//      Debug.log(3, "%c %s %s %s", kc.charValue(),
+//              (codeI[0] == -1 ? "" : KeyEvent.getKeyText(codeI[0])),
+//              (codeI[1] == -1 ? "" : KeyEvent.getKeyText(codeI[1])),
+//              (codeI[2] == -1 ? "" : KeyEvent.getKeyText(codeI[2])));
+//    }
+//  }
 
   /**
    * INTERNAL USE ONLY

--- a/API/src/main/java/org/sikuli/script/Key.java
+++ b/API/src/main/java/org/sikuli/script/Key.java
@@ -3,14 +3,14 @@
  */
 package org.sikuli.script;
 
+import org.sikuli.basics.HotkeyManager;
+import org.sikuli.basics.HotkeyListener;
+import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
-
 import org.sikuli.basics.Debug;
-import org.sikuli.basics.HotkeyListener;
-import org.sikuli.basics.HotkeyManager;
 import org.sikuli.basics.Settings;
 import org.sikuli.natives.WinUtil;
 
@@ -22,7 +22,7 @@ import org.sikuli.natives.WinUtil;
  * for details consult the docs
  */
 public class Key {
-  
+
   /**
    * add a hotkey and listener
    * @param key respective key specifier according class Key
@@ -64,7 +64,7 @@ public class Key {
   public static boolean removeHotkey(char key, int modifiers) {
     return HotkeyManager.getInstance().removeHotkey(key, modifiers);
   }
-      
+
   static String[] keyVK = new String[] {
   //<editor-fold defaultstate="collapsed" desc="VK_xxx constant names and values Java 7">
     "VK_0","48",
@@ -495,8 +495,8 @@ public class Key {
 
   /**
    * Convert Sikuli Key to Java virtual key code
-   * @param key as String
-   * @return the Java KeyCodes
+	 * @param key as String
+	 * @return the Java KeyCodes
    */
   public static int[] toJavaKeyCode(String key) {
     if (key.length() > 0) {
@@ -507,8 +507,8 @@ public class Key {
 
   /**
    * Convert Sikuli Key to Java virtual key code
-   * @param key as Character
-   * @return the Java KeyCodes
+	 * @param key as Character
+	 * @return the Java KeyCodes
    */
   public static int[] toJavaKeyCode(char key) {
     return KeyboardLayout.toJavaKeyCode(key);
@@ -616,7 +616,7 @@ public class Key {
     }
     return modNew;
   }
-  
+
   /**
    * get the lock state of the given key
    *
@@ -648,11 +648,11 @@ public class Key {
     return (state % 2) > 0;
   }
 
-  /**
-   * HotKey modifier to be used with Sikuli's HotKey feature
-   * @return META(CMD) on Mac, CTRL otherwise
-   */
-  public static int getHotkeyModifier() {
+	/**
+	 * HotKey modifier to be used with Sikuli's HotKey feature
+	 * @return META(CMD) on Mac, CTRL otherwise
+	 */
+	public static int getHotkeyModifier() {
     if (Settings.isMac()) {
       return KeyEvent.VK_META;
     } else {
@@ -667,158 +667,158 @@ public class Key {
    * INTERNAL USE ONLY
    * create an alternate keycode table for a non-US keyboard
    */
-//  public static void keyBoardSetup() {
-//    Map<Character, Integer[]> keyLocal = new HashMap<Character, Integer[]>();
-//    String[] keyXX = new String[]{"", "", "", "",};
-//    String keysx = Key.keyboardUS;
+//	public static void keyBoardSetup() {
+//		Map<Character, Integer[]> keyLocal = new HashMap<Character, Integer[]>();
+//		String[] keyXX = new String[]{"", "", "", "",};
+//		String keysx = Key.keyboardUS;
 //
-//    try {
-//      Screen s = new Screen(0);
-//      ImagePath.add("org.sikuli.basics.SikuliX/Images");
+//		try {
+//			Screen s = new Screen(0);
+//			ImagePath.add("org.sikuli.basics.SikuliX/Images");
 //
-//      ShowKeyBoardSetupWindow win = new ShowKeyBoardSetupWindow();
-//      win.start();
-//      s.wait(3.0F);
+//			ShowKeyBoardSetupWindow win = new ShowKeyBoardSetupWindow();
+//			win.start();
+//			s.wait(3.0F);
 //
-//      Location btnOK = s.find("SikuliLogo").getCenter();
-//      Location txtArea = btnOK.offset(0, 400);
-//      s.click(txtArea);
-//      s.wait(1.0F);
-//      String[] mods = new String[]{"", "S", "A", "SA"};
-//      Debug.setDebugLevel(0);
-//      for (String modx : mods) {
-//        s.paste((modx.isEmpty() ? "NO" : modx) + " modifier" + "\n");
-//        if (!modx.isEmpty()) {
-//          if (modx.length() == 1) {
-//            modx = "#" + modx + ".";
-//          } else if (modx.length() == 2) {
-//            modx = "#" + modx.substring(0, 1) + ".#" + modx.substring(1, 2) + ".";
-//          } else {
-//            break;
-//          }
-//        }
-//        String c;
-//        for (int n = 0; n < keysx.length(); n++) {
-//          c = "" + keysx.charAt(n);
-//          s.paste(c);
-//          s.type(" ");
-//          if (Mouse.hasMoved()) {
-//            s.click(txtArea);
-//            s.wait(0.3F);
-//          }
-//          s.write(String.format("%s%s ", modx, c));
-//          if ("=".equals(c) || "]".equals(c) || "\\".equals(c)) {
-//            s.paste("\n");
-//          }
-//        }
-//        s.paste("\n");
-//        s.type(Key.ENTER);
-//      }
-//      Debug.setDebugLevel(3);
-//      s.click(btnOK);
-//    } catch (FindFailed e) {
-//      Debug.error("KeyBoardSetup: Does not work - getting FindFailed");
-//      return;
-//    }
-//    while (true) {
-//      try {
-//        Thread.sleep(1000);
-//      } catch (InterruptedException ex) {
-//      }
-//      Debug.log(3, "waiting for result\n" + result[0]);
-//      if (!result[0].isEmpty()) {
-//        break;
-//      }
-//    }
-//    String[] keyNewx = result[0].split("\n");
-//    String keysNew;
-//    String mod;
-//    int nKDE = 0;
-//    for (int n = 0; n < keyNewx.length; n += 6) {
-//      mod = keyNewx[n].substring(0, 2);
-//      keysNew = keyNewx[n + 1] + keyNewx[n + 2] + keyNewx[n + 3] + keyNewx[n + 4];
-//      keyXX[nKDE] = mod + ": " + keysNew;
-//      Debug.log(3, "%s", keyXX[nKDE]);
-//      nKDE++;
-//    }
-//    String kSet;
-//    int offset = 4;
-//    char keyOld, keyNew;
-//    int[] codeA;
-//    String codeS;
-//    String modText;
-//    int nOld;
-//    for (int n = 0; n < 4; n++) {
-//      kSet = keyXX[n].substring(4);
-//      mod = keyXX[n].substring(0, 2);
-//      modText = "";
-//      if ("S ".equals(mod)) {
-//        modText = "SHIFT ";
-//      } else if ("A ".equals(mod)) {
-//        modText = "ALT ";
-//      } else if ("SA".equals(mod)) {
-//        modText = "SHIFT ALT ";
-//      }
-//      Debug.log(3, mod + "\n" + kSet);
-//      nOld = 0;
-//      for (int i = 0; i < kSet.length(); i++) {
-//        if (i + 3 > kSet.length()) {
-//          break;
-//        }
-//        if (!" ".equals("" + kSet.charAt(i + 3))) {
-//          offset = 3;
-//        }
-//        keyOld = kSet.charAt(i);
-//        keyNew = kSet.charAt(i + 2);
-//        Integer[] codeI = new Integer[]{-1, -1, -1};
-//        try {
-//          codeA = Key.toJavaKeyCode(keyNew);
-//          codeS = "";
-//          for (int iK : codeA) {
-//            codeS += KeyEvent.getKeyText(iK) + " ";
-//          }
-//          if (codeA.length == 1) {
-//            codeI[2] = codeA[0];
-//          } else if (codeA.length == 2) {
-//            codeI[2] = codeA[1];
-//            codeI[0] = codeA[0];
-//          } else if (codeA.length == 3) {
-//            codeI[2] = codeA[2];
-//            codeI[0] = codeA[0];
-//            codeI[1] = codeA[1];
-//          }
-//        } catch (Exception e) {
-//          codeS = "UNKNOWN ";
-//          codeI[2] = Key.toJavaKeyCode(keysx.charAt(nOld))[0];
-//          codeS += modText + KeyEvent.getKeyText(codeI[2]);
-//          for (int ik = 0; ik < 2; ik++) {
-//            if (mod.charAt(ik) == 'S') {
-//              codeI[ik] = KeyEvent.VK_SHIFT;
-//            } else if (mod.charAt(ik) == 'A') {
-//              codeI[ik] = KeyEvent.VK_ALT;
-//            }
-//          }
-//        }
-//        if (keyLocal.get(keyNew) == null) {
-//          keyLocal.put(keyNew, codeI);
-//        }
-//        Debug.log(3, "%s %c %c %s", mod, keyOld, keyNew, codeS);
-//        i += offset - 1;
-//        offset = 4;
-//        nOld += 1;
-//      }
-//    }
+//			Location btnOK = s.find("SikuliLogo").getCenter();
+//			Location txtArea = btnOK.offset(0, 400);
+//			s.click(txtArea);
+//			s.wait(1.0F);
+//			String[] mods = new String[]{"", "S", "A", "SA"};
+//			Debug.setDebugLevel(0);
+//			for (String modx : mods) {
+//				s.paste((modx.isEmpty() ? "NO" : modx) + " modifier" + "\n");
+//				if (!modx.isEmpty()) {
+//					if (modx.length() == 1) {
+//						modx = "#" + modx + ".";
+//					} else if (modx.length() == 2) {
+//						modx = "#" + modx.substring(0, 1) + ".#" + modx.substring(1, 2) + ".";
+//					} else {
+//						break;
+//					}
+//				}
+//				String c;
+//				for (int n = 0; n < keysx.length(); n++) {
+//					c = "" + keysx.charAt(n);
+//					s.paste(c);
+//					s.type(" ");
+//					if (Mouse.hasMoved()) {
+//						s.click(txtArea);
+//						s.wait(0.3F);
+//					}
+//					s.write(String.format("%s%s ", modx, c));
+//					if ("=".equals(c) || "]".equals(c) || "\\".equals(c)) {
+//						s.paste("\n");
+//					}
+//				}
+//				s.paste("\n");
+//				s.type(Key.ENTER);
+//			}
+//			Debug.setDebugLevel(3);
+//			s.click(btnOK);
+//		} catch (FindFailed e) {
+//			Debug.error("KeyBoardSetup: Does not work - getting FindFailed");
+//			return;
+//		}
+//		while (true) {
+//			try {
+//				Thread.sleep(1000);
+//			} catch (InterruptedException ex) {
+//			}
+//			Debug.log(3, "waiting for result\n" + result[0]);
+//			if (!result[0].isEmpty()) {
+//				break;
+//			}
+//		}
+//		String[] keyNewx = result[0].split("\n");
+//		String keysNew;
+//		String mod;
+//		int nKDE = 0;
+//		for (int n = 0; n < keyNewx.length; n += 6) {
+//			mod = keyNewx[n].substring(0, 2);
+//			keysNew = keyNewx[n + 1] + keyNewx[n + 2] + keyNewx[n + 3] + keyNewx[n + 4];
+//			keyXX[nKDE] = mod + ": " + keysNew;
+//			Debug.log(3, "%s", keyXX[nKDE]);
+//			nKDE++;
+//		}
+//		String kSet;
+//		int offset = 4;
+//		char keyOld, keyNew;
+//		int[] codeA;
+//		String codeS;
+//		String modText;
+//		int nOld;
+//		for (int n = 0; n < 4; n++) {
+//			kSet = keyXX[n].substring(4);
+//			mod = keyXX[n].substring(0, 2);
+//			modText = "";
+//			if ("S ".equals(mod)) {
+//				modText = "SHIFT ";
+//			} else if ("A ".equals(mod)) {
+//				modText = "ALT ";
+//			} else if ("SA".equals(mod)) {
+//				modText = "SHIFT ALT ";
+//			}
+//			Debug.log(3, mod + "\n" + kSet);
+//			nOld = 0;
+//			for (int i = 0; i < kSet.length(); i++) {
+//				if (i + 3 > kSet.length()) {
+//					break;
+//				}
+//				if (!" ".equals("" + kSet.charAt(i + 3))) {
+//					offset = 3;
+//				}
+//				keyOld = kSet.charAt(i);
+//				keyNew = kSet.charAt(i + 2);
+//				Integer[] codeI = new Integer[]{-1, -1, -1};
+//				try {
+//					codeA = Key.toJavaKeyCode(keyNew);
+//					codeS = "";
+//					for (int iK : codeA) {
+//						codeS += KeyEvent.getKeyText(iK) + " ";
+//					}
+//					if (codeA.length == 1) {
+//						codeI[2] = codeA[0];
+//					} else if (codeA.length == 2) {
+//						codeI[2] = codeA[1];
+//						codeI[0] = codeA[0];
+//					} else if (codeA.length == 3) {
+//						codeI[2] = codeA[2];
+//						codeI[0] = codeA[0];
+//						codeI[1] = codeA[1];
+//					}
+//				} catch (Exception e) {
+//					codeS = "UNKNOWN ";
+//					codeI[2] = Key.toJavaKeyCode(keysx.charAt(nOld))[0];
+//					codeS += modText + KeyEvent.getKeyText(codeI[2]);
+//					for (int ik = 0; ik < 2; ik++) {
+//						if (mod.charAt(ik) == 'S') {
+//							codeI[ik] = KeyEvent.VK_SHIFT;
+//						} else if (mod.charAt(ik) == 'A') {
+//							codeI[ik] = KeyEvent.VK_ALT;
+//						}
+//					}
+//				}
+//				if (keyLocal.get(keyNew) == null) {
+//					keyLocal.put(keyNew, codeI);
+//				}
+//				Debug.log(3, "%s %c %c %s", mod, keyOld, keyNew, codeS);
+//				i += offset - 1;
+//				offset = 4;
+//				nOld += 1;
+//			}
+//		}
 //
-//    Debug.log(3, "--------------- keyLocal");
-//    Integer[] codeI;
-//    for (Character kc : keyLocal.keySet()) {
-//      codeI = keyLocal.get(kc);
-//      Debug.log(3, "%c %s %s %s", kc.charValue(),
-//              (codeI[0] == -1 ? "" : KeyEvent.getKeyText(codeI[0])),
-//              (codeI[1] == -1 ? "" : KeyEvent.getKeyText(codeI[1])),
-//              (codeI[2] == -1 ? "" : KeyEvent.getKeyText(codeI[2])));
-//    }
-//  }
+//		Debug.log(3, "--------------- keyLocal");
+//		Integer[] codeI;
+//		for (Character kc : keyLocal.keySet()) {
+//			codeI = keyLocal.get(kc);
+//			Debug.log(3, "%c %s %s %s", kc.charValue(),
+//							(codeI[0] == -1 ? "" : KeyEvent.getKeyText(codeI[0])),
+//							(codeI[1] == -1 ? "" : KeyEvent.getKeyText(codeI[1])),
+//							(codeI[2] == -1 ? "" : KeyEvent.getKeyText(codeI[2])));
+//		}
+//	}
 
   /**
    * INTERNAL USE ONLY

--- a/API/src/main/java/org/sikuli/script/KeyboardLayout.java
+++ b/API/src/main/java/org/sikuli/script/KeyboardLayout.java
@@ -1,0 +1,354 @@
+package org.sikuli.script;
+
+import java.awt.event.KeyEvent;
+import java.awt.im.InputContext;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+public class KeyboardLayout {
+  private static final Locale defaultLocale = new Locale("en", "US");
+  
+  private static final Map<Locale, Map<Character, int[]>> LAYOUTS = buildLayouts();
+  
+  private static final int VK_OEM_1 = 0xBA; //OEM_1 (: ;)
+  private static final int VK_OEM_102 = 0xE2; //OEM_102 (> <)
+  private static final int VK_OEM_2 = 0xBF; //OEM_2 (? /)
+  private static final int VK_OEM_3 = 0xC0; //OEM_3 (~ `)
+  private static final int VK_OEM_4 = 0xDB; //OEM_4 ({ [)
+  private static final int VK_OEM_5 = 0xDC; //OEM_5 (| \)
+  private static final int VK_OEM_6 = 0xDD; //OEM_6 (} ])
+  private static final int VK_OEM_7 = 0xDE; //OEM_7 (" ')
+  private static final int VK_OEM_8 = 0xDF; //OEM_8 (§ !)
+  
+  private static final int VK_OEM_ATTN = 0xF0; //Oem Attn
+  private static final int VK_OEM_AUTO = 0xF3; //Auto
+  private static final int VK_OEM_AX = 0xE1; //Ax
+  private static final int VK_OEM_BACKTAB = 0xF5; //Back Tab
+  private static final int VK_OEM_CLEAR = 0xFE; //OemClr
+  private static final int VK_OEM_COMMA = 0xBC; //OEM_COMMA (< ,)
+  private static final int VK_OEM_COPY = 0xF2; //Copy
+  private static final int VK_OEM_CUSEL = 0xEF; //Cu Sel
+  private static final int VK_OEM_ENLW = 0xF4; //Enlw
+  private static final int VK_OEM_FINISH = 0xF1; //Finish
+  private static final int VK_OEM_FJ_LOYA = 0x95; //Loya
+  private static final int VK_OEM_FJ_MASSHOU = 0x93; //Mashu
+  private static final int VK_OEM_FJ_ROYA = 0x96; //Roya
+  private static final int VK_OEM_FJ_TOUROKU = 0x94; //Touroku
+  private static final int  VK_OEM_JUMP = 0xEA; //Jump
+  private static final int VK_OEM_MINUS = 0xBD; //OEM_MINUS (_ -)
+  private static final int VK_OEM_PA1 = 0xEB; //OemPa1
+  private static final int VK_OEM_PA2 = 0xEC; //OemPa2
+  private static final int VK_OEM_PA3 = 0xED; //OemPa3
+  private static final int VK_OEM_PERIOD = 0xBE; //OEM_PERIOD (> .)
+  private static final int VK_OEM_PLUS = 0xBB; //OEM_PLUS (+ =)
+  private static final int VK_OEM_RESET = 0xE9; //Reset
+  private static final int VK_OEM_WSCTR = 0xEE; //WsCtrl
+  
+  private static final int VK_RMENU = 0xA5; //Right ALT
+  private static final int VK_RETURN =  0x0D; //Ente
+
+  private static Map<Locale, Map<Character, int[]>> buildLayouts() {
+        
+    Map<Locale, Map<Character, int[]>> layouts = new HashMap<>();
+
+    layouts.put(defaultLocale, buildEnUs());
+    layouts.put(new Locale("de", "CH"), buildDeCh());
+
+    return layouts;
+  }
+
+  private static Map<Character, int[]> buildEnUs() {
+    Map<Character, int[]> layout = new HashMap<>();
+
+    layout.putAll(buildLatinLowercase());
+    layout.putAll(buildLatinUppercase());
+    layout.putAll(buildArabicNumbers());
+    layout.putAll(buildCommonFunctional());
+
+    // Row 3 (below function keys)
+    // layout.put('§', new int[]{192}); //not producable
+    layout.put('!', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_1 });
+    layout.put('@', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_2 });
+    layout.put('#', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_3 });
+    layout.put('$', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_4 });
+    layout.put('%', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_5 });
+    layout.put('^', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_6 });
+    layout.put('&', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_7 });
+    layout.put('*', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_8 });
+    layout.put('(', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_9 });
+    layout.put(')', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_0 });
+    layout.put('-', new int[] { VK_OEM_MINUS });
+    layout.put('_', new int[] { KeyEvent.VK_SHIFT, VK_OEM_MINUS });
+    layout.put('=', new int[] { VK_OEM_PLUS });
+    layout.put('+', new int[] { KeyEvent.VK_SHIFT, VK_OEM_PLUS });
+    // Row 2
+    // q w e r t y u i o p
+    layout.put('[', new int[] { VK_OEM_4});
+    layout.put('{', new int[] { KeyEvent.VK_SHIFT, VK_OEM_4 });
+    layout.put(']', new int[] { VK_OEM_6 });
+    layout.put('}', new int[] { KeyEvent.VK_SHIFT, VK_OEM_6 });
+    // Row 1
+    // a s d f g h j k l
+    layout.put(';', new int[] { VK_OEM_1 });
+    layout.put(':', new int[] { KeyEvent.VK_SHIFT, VK_OEM_1 });
+    layout.put('\'', new int[] { VK_OEM_7 });
+    layout.put('"', new int[] { KeyEvent.VK_SHIFT, VK_OEM_7 });
+    layout.put('\\', new int[] { VK_OEM_5 });
+    layout.put('|', new int[] { KeyEvent.VK_SHIFT, VK_OEM_5 });
+    // RETURN, BACKSPACE, TAB
+    layout.put('\b', new int[] { KeyEvent.VK_BACK_SPACE });
+    layout.put('\t', new int[] { KeyEvent.VK_TAB });
+    layout.put('\r', new int[] { VK_RETURN });
+    layout.put('\n', new int[] { VK_RETURN });
+    // SPACE
+    layout.put(' ', new int[] { KeyEvent.VK_SPACE });
+    // Row 0 (first above SPACE)
+    layout.put('`', new int[] { VK_OEM_3 });
+    layout.put('~', new int[] { KeyEvent.VK_SHIFT, VK_OEM_3 });
+    // z x c v b n m
+    layout.put(',', new int[] { VK_OEM_COMMA });
+    layout.put('<', new int[] { KeyEvent.VK_SHIFT, VK_OEM_COMMA });
+    layout.put('.', new int[] { VK_OEM_PERIOD });
+    layout.put('>', new int[] { KeyEvent.VK_SHIFT, VK_OEM_PERIOD });
+    layout.put('/', new int[] { VK_OEM_2 });
+    layout.put('?', new int[] { KeyEvent.VK_SHIFT, VK_OEM_2 });
+
+    return layout;
+  }
+
+  private static Map<Character, int[]> buildDeCh() {
+        
+    Map<Character, int[]> layout = new HashMap<>();
+
+    layout.putAll(buildLatinLowercase());
+    layout.putAll(buildLatinUppercase());
+    layout.putAll(buildArabicNumbers());
+    layout.putAll(buildCommonFunctional());
+
+    // Row 3 (below function keys)    
+    layout.put('¨', new int[] { VK_OEM_3 });
+    layout.put('!', new int[] { KeyEvent.VK_SHIFT, VK_OEM_3 });
+    layout.put('@', new int[] { VK_RMENU, KeyEvent.VK_2 });
+    layout.put('#', new int[] { VK_RMENU, KeyEvent.VK_3 });
+    layout.put('$', new int[] { VK_OEM_8 });
+    layout.put('£', new int[] { KeyEvent.VK_SHIFT, VK_OEM_8 });
+    layout.put('%', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_5 });
+    layout.put('^', new int[] { VK_OEM_6 });
+    layout.put('&', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_6 });
+    layout.put('*', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_3 });
+    layout.put('(', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_8 });
+    layout.put(')', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_9 });
+    layout.put('-', new int[] { VK_OEM_MINUS });
+    layout.put('_', new int[] { KeyEvent.VK_SHIFT, VK_OEM_MINUS });
+    layout.put('=', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_0 });
+    layout.put('+', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_1 });
+    layout.put('§', new int[] { VK_OEM_2 });
+    layout.put('°', new int[] { KeyEvent.VK_SHIFT, VK_OEM_2 });
+    layout.put('€', new int[] { VK_RMENU, KeyEvent.VK_E });
+    // Row 2
+    // q w e r t y u i o p
+                   
+    layout.put('[', new int[] { VK_RMENU, VK_OEM_1 }); 
+    layout.put('{', new int[] { VK_RMENU, VK_OEM_5 });
+    layout.put(']', new int[] { VK_RMENU, VK_OEM_3 });
+    layout.put('}', new int[] { VK_RMENU, VK_OEM_8 });
+    // Row 1
+    // a s d f g h j k l
+    layout.put(';', new int[] { KeyEvent.VK_SHIFT, VK_OEM_COMMA });
+    layout.put(':', new int[] { KeyEvent.VK_SHIFT, VK_OEM_PERIOD });
+    layout.put('\'', new int[] { VK_OEM_4 });
+    layout.put('"', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_2 });
+    layout.put('\\', new int[] { VK_RMENU, VK_OEM_102});
+    layout.put('¦', new int[] { VK_RMENU, KeyEvent.VK_1 });
+    layout.put('|', new int[] { VK_RMENU, KeyEvent.VK_7 });
+    // RETURN, BACKSPACE, TAB
+    layout.put('\b', new int[] { KeyEvent.VK_BACK_SPACE });
+    layout.put('\t', new int[] { KeyEvent.VK_TAB });
+    layout.put('\r', new int[] { VK_RETURN });
+    layout.put('\n', new int[] { VK_RETURN });
+    // SPACE
+    layout.put(' ', new int[] { KeyEvent.VK_SPACE });
+    // Row 0 (first above SPACE)
+    layout.put('`', new int[] { KeyEvent.VK_SHIFT, VK_OEM_6 });
+    layout.put('~', new int[] { VK_RMENU, VK_OEM_6 });
+    // z x c v b n m
+    layout.put(',', new int[] { VK_OEM_COMMA });
+    layout.put('<', new int[] { VK_OEM_102 });
+    layout.put('.', new int[] { VK_OEM_PERIOD });
+    layout.put('>', new int[] { KeyEvent.VK_SHIFT, VK_OEM_102 });
+    layout.put('/', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_7 });
+    layout.put('?', new int[] { KeyEvent.VK_SHIFT, VK_OEM_4 });
+    
+    // Umlauts
+    layout.put('ü', new int[] { VK_OEM_1 });
+    layout.put('è', new int[] { KeyEvent.VK_SHIFT, VK_OEM_1 });
+    layout.put('ö', new int[] { VK_OEM_7 });
+    layout.put('é', new int[] { KeyEvent.VK_SHIFT, VK_OEM_7 });
+    layout.put('ä', new int[] { VK_OEM_5 });
+    layout.put('à', new int[] { KeyEvent.VK_SHIFT, VK_OEM_5 });
+            
+    return layout;
+  }
+
+  private static Map<Character, int[]> buildLatinLowercase() {
+    Map<Character, int[]> layout = new HashMap<>();
+    layout.put('a', new int[] { KeyEvent.VK_A });
+    layout.put('b', new int[] { KeyEvent.VK_B });
+    layout.put('c', new int[] { KeyEvent.VK_C });
+    layout.put('d', new int[] { KeyEvent.VK_D });
+    layout.put('e', new int[] { KeyEvent.VK_E });
+    layout.put('f', new int[] { KeyEvent.VK_F });
+    layout.put('g', new int[] { KeyEvent.VK_G });
+    layout.put('h', new int[] { KeyEvent.VK_H });
+    layout.put('i', new int[] { KeyEvent.VK_I });
+    layout.put('j', new int[] { KeyEvent.VK_J });
+    layout.put('k', new int[] { KeyEvent.VK_K });
+    layout.put('l', new int[] { KeyEvent.VK_L });
+    layout.put('m', new int[] { KeyEvent.VK_M });
+    layout.put('n', new int[] { KeyEvent.VK_N });
+    layout.put('o', new int[] { KeyEvent.VK_O });
+    layout.put('p', new int[] { KeyEvent.VK_P });
+    layout.put('q', new int[] { KeyEvent.VK_Q });
+    layout.put('r', new int[] { KeyEvent.VK_R });
+    layout.put('s', new int[] { KeyEvent.VK_S });
+    layout.put('t', new int[] { KeyEvent.VK_T });
+    layout.put('u', new int[] { KeyEvent.VK_U });
+    layout.put('v', new int[] { KeyEvent.VK_V });
+    layout.put('w', new int[] { KeyEvent.VK_W });
+    layout.put('x', new int[] { KeyEvent.VK_X });
+    layout.put('y', new int[] { KeyEvent.VK_Y });
+    layout.put('z', new int[] { KeyEvent.VK_Z });
+    return layout;
+  }
+
+  private static Map<Character, int[]> buildLatinUppercase() {
+    Map<Character, int[]> layout = new HashMap<>();
+    layout.put('A', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_A });
+    layout.put('B', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_B });
+    layout.put('C', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_C });
+    layout.put('D', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_D });
+    layout.put('E', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_E });
+    layout.put('F', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_F });
+    layout.put('G', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_G });
+    layout.put('H', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_H });
+    layout.put('I', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_I });
+    layout.put('J', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_J });
+    layout.put('K', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_K });
+    layout.put('L', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_L });
+    layout.put('M', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_M });
+    layout.put('N', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_N });
+    layout.put('O', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_O });
+    layout.put('P', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_P });
+    layout.put('Q', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_Q });
+    layout.put('R', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_R });
+    layout.put('S', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_S });
+    layout.put('T', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_T });
+    layout.put('U', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_U });
+    layout.put('V', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_V });
+    layout.put('W', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_W });
+    layout.put('X', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_X });
+    layout.put('Y', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_Y });
+    layout.put('Z', new int[] { KeyEvent.VK_SHIFT, KeyEvent.VK_Z });
+    return layout;
+  }
+
+  private static Map<Character, int[]> buildArabicNumbers() {
+    Map<Character, int[]> layout = new HashMap<>();
+    layout.put('1', new int[] { KeyEvent.VK_1 });
+    layout.put('2', new int[] { KeyEvent.VK_2 });
+    layout.put('3', new int[] { KeyEvent.VK_3 });
+    layout.put('4', new int[] { KeyEvent.VK_4 });
+    layout.put('5', new int[] { KeyEvent.VK_5 });
+    layout.put('6', new int[] { KeyEvent.VK_6 });
+    layout.put('7', new int[] { KeyEvent.VK_7 });
+    layout.put('8', new int[] { KeyEvent.VK_8 });
+    layout.put('9', new int[] { KeyEvent.VK_9 });
+    layout.put('0', new int[] { KeyEvent.VK_0 });
+    return layout;
+  }
+
+  private static Map<Character, int[]> buildCommonFunctional() {
+    Map<Character, int[]> layout = new HashMap<>();
+    // Modifier
+    layout.put(Key.C_SHIFT, new int[] { KeyEvent.VK_SHIFT });
+    layout.put(Key.C_CTRL, new int[] { KeyEvent.VK_CONTROL });
+    layout.put(Key.C_ALT, new int[] { KeyEvent.VK_ALT });
+    layout.put(Key.C_META, new int[] { KeyEvent.VK_META });
+    // Cursor movement
+    layout.put(Key.C_UP, new int[] { KeyEvent.VK_UP });
+    layout.put(Key.C_RIGHT, new int[] { KeyEvent.VK_RIGHT });
+    layout.put(Key.C_DOWN, new int[] { KeyEvent.VK_DOWN });
+    layout.put(Key.C_LEFT, new int[] { KeyEvent.VK_LEFT });
+    layout.put(Key.C_PAGE_UP, new int[] { KeyEvent.VK_PAGE_UP });
+    layout.put(Key.C_PAGE_DOWN, new int[] { KeyEvent.VK_PAGE_DOWN });
+    layout.put(Key.C_END, new int[] { KeyEvent.VK_END });
+    layout.put(Key.C_HOME, new int[] { KeyEvent.VK_HOME });
+    layout.put(Key.C_DELETE, new int[] { KeyEvent.VK_DELETE });
+    // Function keys
+    layout.put(Key.C_ESC, new int[] { KeyEvent.VK_ESCAPE });
+    layout.put(Key.C_F1, new int[] { KeyEvent.VK_F1 });
+    layout.put(Key.C_F2, new int[] { KeyEvent.VK_F2 });
+    layout.put(Key.C_F3, new int[] { KeyEvent.VK_F3 });
+    layout.put(Key.C_F4, new int[] { KeyEvent.VK_F4 });
+    layout.put(Key.C_F5, new int[] { KeyEvent.VK_F5 });
+    layout.put(Key.C_F6, new int[] { KeyEvent.VK_F6 });
+    layout.put(Key.C_F7, new int[] { KeyEvent.VK_F7 });
+    layout.put(Key.C_F8, new int[] { KeyEvent.VK_F8 });
+    layout.put(Key.C_F9, new int[] { KeyEvent.VK_F9 });
+    layout.put(Key.C_F10, new int[] { KeyEvent.VK_F10 });
+    layout.put(Key.C_F11, new int[] { KeyEvent.VK_F11 });
+    layout.put(Key.C_F12, new int[] { KeyEvent.VK_F12 });
+    layout.put(Key.C_F13, new int[] { KeyEvent.VK_F13 });
+    layout.put(Key.C_F14, new int[] { KeyEvent.VK_F14 });
+    layout.put(Key.C_F15, new int[] { KeyEvent.VK_F15 });
+    // Toggling kezs
+    layout.put(Key.C_SCROLL_LOCK, new int[] { KeyEvent.VK_SCROLL_LOCK });
+    layout.put(Key.C_NUM_LOCK, new int[] { KeyEvent.VK_NUM_LOCK });
+    layout.put(Key.C_CAPS_LOCK, new int[] { KeyEvent.VK_CAPS_LOCK });
+    layout.put(Key.C_INSERT, new int[] { KeyEvent.VK_INSERT });
+    // Windows special
+    layout.put(Key.C_PAUSE, new int[] { KeyEvent.VK_PAUSE });
+    layout.put(Key.C_PRINTSCREEN, new int[] { KeyEvent.VK_PRINTSCREEN });
+    // Num pad
+    layout.put(Key.C_NUM0, new int[] { KeyEvent.VK_NUMPAD0 });
+    layout.put(Key.C_NUM1, new int[] { KeyEvent.VK_NUMPAD1 });
+    layout.put(Key.C_NUM2, new int[] { KeyEvent.VK_NUMPAD2 });
+    layout.put(Key.C_NUM3, new int[] { KeyEvent.VK_NUMPAD3 });
+    layout.put(Key.C_NUM4, new int[] { KeyEvent.VK_NUMPAD4 });
+    layout.put(Key.C_NUM5, new int[] { KeyEvent.VK_NUMPAD5 });
+    layout.put(Key.C_NUM6, new int[] { KeyEvent.VK_NUMPAD6 });
+    layout.put(Key.C_NUM7, new int[] { KeyEvent.VK_NUMPAD7 });
+    layout.put(Key.C_NUM8, new int[] { KeyEvent.VK_NUMPAD8 });
+    layout.put(Key.C_NUM9, new int[] { KeyEvent.VK_NUMPAD9 });
+    // Num pad special
+    layout.put(Key.C_SEPARATOR, new int[] { KeyEvent.VK_SEPARATOR });
+    layout.put(Key.C_ADD, new int[] { KeyEvent.VK_ADD });
+    layout.put(Key.C_MINUS, new int[] { KeyEvent.VK_SUBTRACT });
+    layout.put(Key.C_MULTIPLY, new int[] { KeyEvent.VK_MULTIPLY });
+    layout.put(Key.C_DIVIDE, new int[] { KeyEvent.VK_DIVIDE });
+    layout.put(Key.C_DECIMAL, new int[] { KeyEvent.VK_DECIMAL });
+    layout.put(Key.C_CONTEXT, new int[] { KeyEvent.VK_CONTEXT_MENU });
+    layout.put(Key.C_WIN, new int[] { KeyEvent.VK_WINDOWS });
+    // hack: alternative tab in GUI
+    layout.put(Key.C_NEXT, new int[] { -KeyEvent.VK_TAB });
+    return layout;
+  }
+  
+  public static int[] toJavaKeyCode(char c) {              
+    Map<Character, int[]> layout = LAYOUTS.get(InputContext.getInstance().getLocale());   
+    
+    if(layout == null){
+      layout = LAYOUTS.get(defaultLocale);
+    }
+    
+    int[] codes = layout.get(c);
+
+    if (codes == null) {
+      throw new IllegalArgumentException("Key: Not supported character: " + c);
+    }
+
+    return codes;
+  }
+
+}

--- a/API/src/main/java/org/sikuli/script/KeyboardLayout.java
+++ b/API/src/main/java/org/sikuli/script/KeyboardLayout.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.sikuli.basics.Settings;
 import org.sikuli.natives.SXUser32;
 
 import com.sun.jna.Platform;
@@ -332,7 +333,7 @@ public class KeyboardLayout {
   private static Map<Character, int[]> getCurrentLayout(){
     Map<Character, int[]> layout = DEFAULT_KEYBOARD_LAYOUT;
 
-    if (Platform.isWindows()) {
+    if (Settings.AutoDetectKeyboardLayout && Settings.isWindows()) {
           int keyboarLayoutId = DEFAULT_KEYBOARD_LAYOUT_ID;
       HWND hwnd = sxuser32.GetForegroundWindow();
       if (hwnd != null) {

--- a/API/src/main/java/org/sikuli/script/RobotDesktop.java
+++ b/API/src/main/java/org/sikuli/script/RobotDesktop.java
@@ -114,7 +114,7 @@ public class RobotDesktop extends Robot implements IRobot {
     // on Windows we detect the current layout in KeyboardLayout.
     // Since this layout is not compatible to AWT Robot, we have to use
     // the User32 API to simulate the key press
-    if (Platform.isWindows()) {
+    if (Settings.AutoDetectKeyboardLayout && Settings.isWindows()) {
       WinUser.INPUT input = new WinUser.INPUT();
       input.type = new WinDef.DWORD(WinUser.INPUT.INPUT_KEYBOARD);
       input.input.setType("ki");
@@ -145,7 +145,7 @@ public class RobotDesktop extends Robot implements IRobot {
     // on Windows we detect the current layout in KeyboardLayout.
     // Since this layout is not compatible to AWT Robot, we have to use
     // the User32 API to simulate the key release
-    if (Platform.isWindows()) {
+    if (Settings.AutoDetectKeyboardLayout && Settings.isWindows()) {
       WinUser.INPUT input = new WinUser.INPUT();
       input.type = new WinDef.DWORD(WinUser.INPUT.INPUT_KEYBOARD);
       input.input.setType("ki");

--- a/API/src/main/java/org/sikuli/script/RobotDesktop.java
+++ b/API/src/main/java/org/sikuli/script/RobotDesktop.java
@@ -111,7 +111,9 @@ public class RobotDesktop extends Robot implements IRobot {
       delay(20);
     }
     
-    
+    // on Windows we detect the current layout in KeyboardLayout.
+    // Since this layout is not compatible to AWT Robot, we have to use
+    // the User32 API to simulate the key press
     if (Platform.isWindows()) {
       WinUser.INPUT input = new WinUser.INPUT();
       input.type = new WinDef.DWORD(WinUser.INPUT.INPUT_KEYBOARD);
@@ -140,6 +142,9 @@ public class RobotDesktop extends Robot implements IRobot {
     setAutoDelay(stdAutoDelay);
     setAutoWaitForIdle(false);
     
+    // on Windows we detect the current layout in KeyboardLayout.
+    // Since this layout is not compatible to AWT Robot, we have to use
+    // the User32 API to simulate the key release
     if (Platform.isWindows()) {
       WinUser.INPUT input = new WinUser.INPUT();
       input.type = new WinDef.DWORD(WinUser.INPUT.INPUT_KEYBOARD);

--- a/API/src/main/java/org/sikuli/script/RobotDesktop.java
+++ b/API/src/main/java/org/sikuli/script/RobotDesktop.java
@@ -9,6 +9,12 @@ import org.sikuli.basics.AnimatorTimeBased;
 import org.sikuli.basics.Settings;
 import org.sikuli.basics.Debug;
 
+import com.sun.jna.Platform;
+import com.sun.jna.platform.win32.BaseTSD;
+import com.sun.jna.platform.win32.User32;
+import com.sun.jna.platform.win32.WinDef;
+import com.sun.jna.platform.win32.WinUser;
+
 import java.awt.AWTException;
 import java.awt.Color;
 import java.awt.MouseInfo;
@@ -104,7 +110,25 @@ public class RobotDesktop extends Robot implements IRobot {
       Region.getFakeRegion().silentHighlight(false);
       delay(20);
     }
-    keyPress(keyCode);
+    
+    
+    if (Platform.isWindows()) {
+      WinUser.INPUT input = new WinUser.INPUT();
+      input.type = new WinDef.DWORD(WinUser.INPUT.INPUT_KEYBOARD);
+      input.input.setType("ki");
+      input.input.ki.wScan = new WinDef.WORD(0);
+      input.input.ki.time = new WinDef.DWORD(0);
+      input.input.ki.dwExtraInfo = new BaseTSD.ULONG_PTR(0);
+      input.input.ki.wVk = new WinDef.WORD(keyCode);
+      input.input.ki.dwFlags = new WinDef.DWORD(0);
+
+      User32.INSTANCE.SendInput(new WinDef.DWORD(1),
+          (WinUser.INPUT[]) input.toArray(1), input.size());
+    }else{
+      keyPress(keyCode);
+    }
+    
+    
     if (stdAutoDelay == 0) {
       delay(stdDelay);
     }
@@ -115,7 +139,24 @@ public class RobotDesktop extends Robot implements IRobot {
     logRobot(stdAutoDelay, "KeyRelease: WaitForIdle: %s - Delay: %d");
     setAutoDelay(stdAutoDelay);
     setAutoWaitForIdle(false);
-    keyRelease(keyCode);
+    
+    if (Platform.isWindows()) {
+      WinUser.INPUT input = new WinUser.INPUT();
+      input.type = new WinDef.DWORD(WinUser.INPUT.INPUT_KEYBOARD);
+      input.input.setType("ki");
+      input.input.ki.wScan = new WinDef.WORD(0);
+      input.input.ki.time = new WinDef.DWORD(0);
+      input.input.ki.dwExtraInfo = new BaseTSD.ULONG_PTR(0);  
+      input.input.ki.wVk = new WinDef.WORD(keyCode);
+      input.input.ki.dwFlags = new WinDef.DWORD(
+          WinUser.KEYBDINPUT.KEYEVENTF_KEYUP);
+
+      User32.INSTANCE.SendInput(new WinDef.DWORD(1),
+          (WinUser.INPUT[]) input.toArray(1), input.size());
+    }else{
+      keyRelease(keyCode);
+    }
+    
     if (stdAutoDelay == 0) {
       delay(stdDelay);
     }


### PR DESCRIPTION
The SikuliX type function only reliably works with the US keyboard layout .

This due to the fact that the key code combinations are hard coded in the Key class. And even if the key combinations wouldn't be hard coded, AWT Robot can't handle key codes for unicode characters (e.g. öäü on German keyboards) at all.

The new implementation bypasses AWT Robot entirely for key presses and key releases on Windows (other OSes still use AWT Robot with the default behaviour and the hard coded US layout). 

It automatically builds a key mapping based on the currently selected locale (similar to the native implementation in https://github.com/frohoff/jdk8u-jdk/blob/master/src/windows/native/sun/windows/awt_Component.cpp, but with full Unicode support). Then it uses this mapping to get the key code for a character and uses the Windows API to simulate a key press / release.
