### PR TITLE
Override equals for ScreenImage to perform a pixel comparison

### DIFF
--- a/API/src/main/java/org/sikuli/script/ScreenImage.java
+++ b/API/src/main/java/org/sikuli/script/ScreenImage.java
@@ -224,5 +224,32 @@ public class ScreenImage {
   		ImageIO.write(_img, "png", new File(fPath, "LastScreenImage.png"));
     } catch (Exception ex) {}
   }
+  
+  @Override
+  public boolean equals(Object other) {    
+    if(this == other) {
+      return true;
+    }
+    
+    if(other == null || !(other instanceof ScreenImage)) {
+      return false;
+    }    
+           
+    BufferedImage img1 = this.getImage();
+    BufferedImage img2 = ((ScreenImage) other).getImage();
+    
+    if (img1.getWidth() == img2.getWidth() && img1.getHeight() == img2.getHeight()) {
+      for (int x = 0; x < img1.getWidth(); x++) {
+          for (int y = 0; y < img1.getHeight(); y++) {
+              if (img1.getRGB(x, y) != img2.getRGB(x, y))
+                  return false;
+          }
+      }
+    } else {
+        return false;
+    }
+    
+    return true;    
+  }
 
 }


### PR DESCRIPTION
Relatively fast method to test if two ScreenImages are exactly the same. Can sometimes be convenient in scripts to just compare for example two screenshots like scr1.equals(scr2).