### PR TITLE
Fix async script runner init with -r option

### DIFF
--- a/IDE/src/main/java/org/sikuli/ide/SikuliIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikuliIDE.java
@@ -252,7 +252,7 @@ public class SikuliIDE extends JFrame implements InvocationHandler {
     Debug.log(3, "IDE: Init ScriptingSupport");
     //ideSplash.showStep("Init ScriptingSupport");
 
-    ScriptingSupport.init();
+    ScriptingSupport.init(true);
     IDESupport.initIDESupport();
     sikulixIDE.initSikuliIDE(args);
   }

--- a/IDE/src/main/java/org/sikuli/scriptrunner/ScriptingSupport.java
+++ b/IDE/src/main/java/org/sikuli/scriptrunner/ScriptingSupport.java
@@ -271,72 +271,71 @@ public class ScriptingSupport {
   }
 
   private static boolean isReady = false;
-  private static boolean runningInit = false;
-
-  public static void init() {
-    if (isReady) {
-      return;
-    }
-    if (runningInit) {
-      System.out.println("ScriptingSupport: waiting for startup init");
-      while (runningInit) {
-        RunTime.pause(1);
+ 
+  public static void init(boolean async) {
+    synchronized(scriptRunner) {
+      if (isReady) {
+        return;
       }
-      return;
-    }
-    runningInit = true;
-		log(lvl, "initScriptingSupport: enter");
-    if (scriptRunner.isEmpty()) {
-      ServiceLoader<IScriptRunner> rloader = ServiceLoader.load(IScriptRunner.class);
-      Iterator<IScriptRunner> rIterator = rloader.iterator();
-      while (rIterator.hasNext()) {
-        IScriptRunner current = null;
-				try {
-					current = rIterator.next();
-				} catch (ServiceConfigurationError e) {
-					log(lvl, "initScriptingSupport: warning: %s", e.getMessage());
-					continue;
-				}
-        String name = current.getName();
-        if (name != null && !name.startsWith("Not")) {
-          scriptRunner.put(name, current);
-          Thread currentInit = new ScriptRunnerInit(current) {
-          };
-          currentInit.start();
-					log(lvl, "initScriptingSupport: added: %s", name);
-        }
-      }
-    }
-    if (scriptRunner.isEmpty()) {
-      String em = "Terminating: No scripting support available. Rerun Setup!";
-      log(-1, em);
-      if (runTime.isRunningIDE) {
-        Sikulix.popError(em, "IDE has problems ...");
-      }
-      System.exit(1);
-    } else {
-      //TODO JavaScript only script support
-      Runner.RDEFAULT = (String) scriptRunner.keySet().toArray()[0];
-      Runner.EDEFAULT = scriptRunner.get(Runner.RDEFAULT).getFileEndings()[0];
-      if (Runner.EDEFAULT == "js" && scriptRunner.size() > 1) {
-        Runner.RDEFAULT = (String) scriptRunner.keySet().toArray()[1];
-        Runner.EDEFAULT = scriptRunner.get(Runner.RDEFAULT).getFileEndings()[0];
-      }
-      for (IScriptRunner r : scriptRunner.values()) {
-        for (String e : r.getFileEndings()) {
-          if (!supportedRunner.containsKey(Runner.endingTypes.get(e))) {
-            supportedRunner.put(Runner.endingTypes.get(e), r);
+      
+  		log(lvl, "initScriptingSupport: enter");
+      if (scriptRunner.isEmpty()) {
+        ServiceLoader<IScriptRunner> rloader = ServiceLoader.load(IScriptRunner.class);
+        Iterator<IScriptRunner> rIterator = rloader.iterator();
+        while (rIterator.hasNext()) {
+          IScriptRunner current = null;
+  				try {
+  					current = rIterator.next();
+  				} catch (ServiceConfigurationError e) {
+  					log(lvl, "initScriptingSupport: warning: %s", e.getMessage());
+  					continue;
+  				}
+          String name = current.getName();
+          if (name != null && !name.startsWith("Not")) {
+            scriptRunner.put(name, current);
+            
+            if(async) {
+              Thread currentInit = new ScriptRunnerInit(current) {
+              };
+              currentInit.start();
+            }else {
+              current.init(null);
+            }  					
+            
+            log(lvl, "initScriptingSupport: added: %s", name);
           }
         }
       }
+      if (scriptRunner.isEmpty()) {
+        String em = "Terminating: No scripting support available. Rerun Setup!";
+        log(-1, em);
+        if (runTime.isRunningIDE) {
+          Sikulix.popError(em, "IDE has problems ...");
+        }
+        System.exit(1);
+      } else {
+        //TODO JavaScript only script support
+        Runner.RDEFAULT = (String) scriptRunner.keySet().toArray()[0];
+        Runner.EDEFAULT = scriptRunner.get(Runner.RDEFAULT).getFileEndings()[0];
+        if (Runner.EDEFAULT == "js" && scriptRunner.size() > 1) {
+          Runner.RDEFAULT = (String) scriptRunner.keySet().toArray()[1];
+          Runner.EDEFAULT = scriptRunner.get(Runner.RDEFAULT).getFileEndings()[0];
+        }
+        for (IScriptRunner r : scriptRunner.values()) {
+          for (String e : r.getFileEndings()) {
+            if (!supportedRunner.containsKey(Runner.endingTypes.get(e))) {
+              supportedRunner.put(Runner.endingTypes.get(e), r);
+            }
+          }
+        }
+      }
+  		log(lvl, "initScriptingSupport: exit with defaultrunner: %s (%s)", Runner.RDEFAULT, Runner.EDEFAULT);
+      isReady = true;
     }
-		log(lvl, "initScriptingSupport: exit with defaultrunner: %s (%s)", Runner.RDEFAULT, Runner.EDEFAULT);
-    runningInit = false;
-    isReady = true;
   }
 
   public static IScriptRunner getRunner(String script, String type) {
-    init();
+    init(false);
     IScriptRunner currentRunner = null;
     String ending = null;
     if (script != null) {
@@ -479,7 +478,7 @@ public class ScriptingSupport {
    */
   public static int run(String scriptPath, String[] args) {
     runAsTest = false;
-    init();
+    init(false);
     String savePath = ImagePath.getBundlePath();
     int retVal = new RunBox(scriptPath, args, runAsTest).run();
     ImagePath.setBundlePath(savePath);
@@ -587,7 +586,7 @@ public class ScriptingSupport {
         if (Runner.RJSCRIPT.equals(givenScriptScriptType)) {
           exitCode = Runner.runjs(null, uGivenScript, givenScriptScript, args);
         } else {
-          ScriptingSupport.init();
+          ScriptingSupport.init(false);
 					currentRunner = scriptRunner.get(givenScriptScriptType);
           if (null == currentRunner) {
             log(-1, "running from net not supported for %s\n%s", givenScriptScriptType, uGivenScript);


### PR DESCRIPTION
Under some circumstances, the new ansync script runner initialization breaks scripts running with the -r option. This due to the fact that in such a case ScriptingSupport.init() gets called and returns immediately (this is lesser an issue inside the IDE because we don't run scripts immediately after the init call).

Adding an async parameter which can be set to true when initalizing from SikulixIDE or false otherwise mitigate that issue (although I'm not sure if this is really the final solution).

Furthermore the implementation with the runningInit flag and the while loop was not thread safe. The synchronized block has the same effect, is thread safe and overall more elegant :-)
 