### PR TITLE
Lazily load runners in case of synchronous ScriptingSupport init

### DIFF
--- a/IDE/src/main/java/org/sikuli/scriptrunner/JRubyScriptRunner.java
+++ b/IDE/src/main/java/org/sikuli/scriptrunner/JRubyScriptRunner.java
@@ -86,7 +86,7 @@ public class JRubyScriptRunner implements IScriptRunner {
   private static ThreadContext context;
 
 	@Override
-	public void init(String[] args) {
+	public synchronized void init(String[] args) {
 		//TODO classpath and other path handlings
 		sikuliLibPath = sxRunTime.fSikulixLib.getAbsolutePath();
 	}

--- a/IDE/src/main/java/org/sikuli/scriptrunner/JSScriptRunner.java
+++ b/IDE/src/main/java/org/sikuli/scriptrunner/JSScriptRunner.java
@@ -25,7 +25,7 @@ public class JSScriptRunner implements IScriptRunner {
 
 
   @Override
-  public void init(String[] args) {
+  public synchronized void init(String[] args) {
     if (isReady) {
       return;
     }

--- a/IDE/src/main/java/org/sikuli/scriptrunner/JythonScriptRunner.java
+++ b/IDE/src/main/java/org/sikuli/scriptrunner/JythonScriptRunner.java
@@ -528,7 +528,7 @@ public class JythonScriptRunner implements IScriptRunner {
     }
   }
 
-  private PythonInterpreter getInterpreter() {
+  private synchronized PythonInterpreter getInterpreter() {
     if (interpreter == null) {
       sysargv.add("");
       PythonInterpreter.initialize(System.getProperties(), null, sysargv.toArray(new String[0]));

--- a/IDE/src/main/java/org/sikuli/scriptrunner/JythonScriptRunner.java
+++ b/IDE/src/main/java/org/sikuli/scriptrunner/JythonScriptRunner.java
@@ -88,7 +88,7 @@ public class JythonScriptRunner implements IScriptRunner {
   private boolean isFromIDE = false;
 
   @Override
-  public void init(String[] param) {
+  public synchronized void init(String[] param) {
     if (isReady && interpreter != null) {
       return;
     }

--- a/IDE/src/main/java/org/sikuli/scriptrunner/RemoteRunner.java
+++ b/IDE/src/main/java/org/sikuli/scriptrunner/RemoteRunner.java
@@ -18,7 +18,7 @@ public class RemoteRunner {
     init(adr, p);
   }
 
-  private void init(String adr, String p) {
+  private synchronized void init(String adr, String p) {
 
   }
 


### PR DESCRIPTION
Implementing this lazy loading stuff was simpler than expected. Almost everything is already there.

Now, if ScriptingSupport.init is done synchronously (e.g. IDE with -r) the runners are not initialized immediately anymore. Instead, initialization is started inside the getRunner() before the runner starts for the first time.
In case of the asynchronous init (IDE without -r), all runners are still initialized immediately.

Now we have the best of  both worlds. Fast IDE startup and fast script runs using the -r option.

See issue #94