### PR TITLE
Make line number context menu working on windows

### DIFF
--- a/IDE/src/main/java/org/sikuli/ide/EditorLineNumberView.java
+++ b/IDE/src/main/java/org/sikuli/ide/EditorLineNumberView.java
@@ -293,6 +293,9 @@ public class EditorLineNumberView extends JComponent implements MouseListener {
 
   @Override
   public void mouseReleased(MouseEvent me) {
+    if (me.isPopupTrigger()) {
+      shouldPopup = true;
+    }
   }
 
   //</editor-fold>


### PR DESCRIPTION
Line number popup was not working on Windows.

The Javadoc of MouseEvent.isPopupTrigger() gives the explanation:

> isPopupTrigger
> public boolean isPopupTrigger()
> Returns whether or not this mouse event is the popup menu trigger event for the platform.
> Note: Popup menus are triggered differently on different systems. Therefore, isPopupTrigger should be checked in both mousePressed and mouseReleased for proper cross-platform functionality.