### PR TITLE
fixed: SikulixRunner: run with script args

### DIFF
--- a/API/src/main/java/org/sikuli/script/runners/SikulixRunner.java
+++ b/API/src/main/java/org/sikuli/script/runners/SikulixRunner.java
@@ -34,7 +34,7 @@ public class SikulixRunner extends AbstractScriptRunner {
     
     File innerScriptFile = Runner.getScriptFile(new File(scriptFile));
             
-    return Runner.run(innerScriptFile.getAbsolutePath());     
+    return Runner.run(innerScriptFile.getAbsolutePath(), scriptArgs);     
   }
    
   @Override


### PR DESCRIPTION
I found a small bug and fixed it. I'm glad if it help you.

- org.sikuli.script.runners.SikulixRunner : call Runner#run() without script args