### PR TITLE
fixed: WinUtil: getWindow() return null when App isn't running

### DIFF
--- a/API/src/main/java/org/sikuli/natives/WinUtil.java
+++ b/API/src/main/java/org/sikuli/natives/WinUtil.java
@@ -411,7 +411,7 @@ public class WinUtil implements OSUtil {
   public Rectangle getWindow(App app, int winNum) {
     get(app);
     if (!app.isValid()) {
-      return new Rectangle();
+      return null;
     }
     return getWindow(app.getPID(), winNum);
   }


### PR DESCRIPTION
Hello RaiMan,

I found a small bug and fixed it.

- org.sikuli.natives.WinUtil : getWindow(App app, int winNum) not return null when App isn't running


**Detail**
I read and tried https://sikulix-2014.readthedocs.io/en/latest/appclass.html#window .
```
# using an existing window if possible
myApp = App("Firefox")
if not myApp.window(): # no window(0) - Firefox not open
        App.open("c:\\Program Files\\Mozilla Firefox\\Firefox.exe")
        wait(2)
myApp.focus()
wait(1)
type("l", KEY_CTRL) # switch to address field
```
I expected myApp.window() return None when Firefox not open.
But, myApp.window() return Region object.