### PR TITLE
Bring back -f option

### DIFF
--- a/API/src/main/java/org/sikuli/script/support/RunTime.java
+++ b/API/src/main/java/org/sikuli/script/support/RunTime.java
@@ -190,6 +190,10 @@ public class RunTime {
       Debug.globalTraceOn();
       Debug.setStartWithTrace();
     }
+    
+    if(!getLogFile().isEmpty()) {
+      Debug.setLogFile(getLogFile());
+    }
 
     if (runningScripts()) {
       int exitCode = Runner.runScripts(RunTime.getRunScripts());


### PR DESCRIPTION
The -f option must have been lost somewhere.

This commit brings it back setting the log file of Debug.