### PR TITLE
Windows hotkey startup

### DIFF
--- a/API/src/main/java/com/tulskiy/keymaster/windows/WindowsProvider.java
+++ b/API/src/main/java/com/tulskiy/keymaster/windows/WindowsProvider.java
@@ -53,7 +53,7 @@ public class WindowsProvider extends Provider {
         /*
          * Loading keymaster's User32 (together with its native library) inside the 
          * Runnable thread sometimes throws an UnsatisfiedLinkError.
-         * This mainly happens slower machines, seems to be a timing issue.
+         * This mainly happens on slower machines, seems to be a timing issue.
          * Having the msg initialization outside the Runnable triggers the native
          * library loading in the main tread.
          */
@@ -61,7 +61,7 @@ public class WindowsProvider extends Provider {
       
         Runnable runnable = new Runnable() {
             public void run() {
-                //LOGGER.info("Starting Windows global hotkey provider"); 
+                //LOGGER.info("Starting Windows global hotkey provider");
                 //MSG msg = new MSG();
                 listen = true;
                 while (listen) {

--- a/API/src/main/java/com/tulskiy/keymaster/windows/WindowsProvider.java
+++ b/API/src/main/java/com/tulskiy/keymaster/windows/WindowsProvider.java
@@ -50,15 +50,19 @@ public class WindowsProvider extends Provider {
     private Queue<HotKey> registerQueue = new LinkedList<HotKey>();
 
     public void init() {
-        // Initializing msg outside of the Runnable ensures that the
-        // keymaster's User32 (together with its native library) gets loaded during
-        // the class loading phase. Loading it inside the Runnable gives a
-        // UnsatisfiedLinkError sometimes.
+        /*
+         * Loading keymaster's User32 (together with its native library) inside the 
+         * Runnable thread sometimes throws an UnsatisfiedLinkError.
+         * This mainly happens slower machines, seems to be a timing issue.
+         * Having the msg initialization outside the Runnable triggers the native
+         * library loading in the main tread.
+         */
         MSG msg = new MSG();
       
         Runnable runnable = new Runnable() {
             public void run() {
-                //LOGGER.info("Starting Windows global hotkey provider");               
+                //LOGGER.info("Starting Windows global hotkey provider"); 
+                //MSG msg = new MSG();
                 listen = true;
                 while (listen) {
                     while (PeekMessage(msg, null, 0, 0, PM_REMOVE)) {

--- a/API/src/main/java/com/tulskiy/keymaster/windows/WindowsProvider.java
+++ b/API/src/main/java/com/tulskiy/keymaster/windows/WindowsProvider.java
@@ -50,10 +50,15 @@ public class WindowsProvider extends Provider {
     private Queue<HotKey> registerQueue = new LinkedList<HotKey>();
 
     public void init() {
+        // Initializing msg outside of the Runnable ensures that the
+        // keymaster's User32 (together with its native library) gets loaded during
+        // the class loading phase. Loading it inside the Runnable gives a
+        // UnsatisfiedLinkError sometimes.
+        MSG msg = new MSG();
+      
         Runnable runnable = new Runnable() {
             public void run() {
-                //LOGGER.info("Starting Windows global hotkey provider");
-                MSG msg = new MSG();
+                //LOGGER.info("Starting Windows global hotkey provider");               
                 listen = true;
                 while (listen) {
                     while (PeekMessage(msg, null, 0, 0, PM_REMOVE)) {


### PR DESCRIPTION
We sometimes got a UnsitisfiedLinkError while starting up the SikuliX IDE (Windows only, mainly on slow machines):

`Exception in thread "Thread-3" java.lang.UnsatisfiedLinkError: Failed to create temporary file for /com/sun/jna/win32-x86-64/jnidispatch.dll library: Stream closed
        at com.sun.jna.Native.loadNativeDispatchLibraryFromClasspath(Native.java:962)
        at com.sun.jna.Native.loadNativeDispatchLibrary(Native.java:922)
        at com.sun.jna.Native.<clinit>(Native.java:190)
        at com.sun.jna.Pointer.<clinit>(Pointer.java:54)
        at com.sun.jna.Structure.<clinit>(Structure.java:2130)
        at com.tulskiy.keymaster.windows.WindowsProvider$1.run(WindowsProvider.java:56)
        at java.lang.Thread.run(Thread.java:748)`

Some debugging showed that there seems to be a problem when keymasters User32 (and its native library) gets loaded inside the Runnable Thread. After some trial and error I figured out that the least intrusive way to fix the issue would be to move the msg initalization outside of the Runnable. This triggers the class loading inside the main thread.

I just ask myself if this is the right place to fix the issue since this seems to be copied from https://github.com/tulskiy/jkeymaster. On the other hand the last commit in this repo was done on 2016-02-23, so it seems to be dead.