### PR TITLE
Synchronizes KeyboardLayout generation and uses native WaitForInputIdle

### DIFF
--- a/API/src/main/java/org/sikuli/natives/SXUser32.java
+++ b/API/src/main/java/org/sikuli/natives/SXUser32.java
@@ -9,14 +9,17 @@ public interface SXUser32 extends User32 {
   SXUser32 INSTANCE = (SXUser32) Native.loadLibrary("user32", SXUser32.class, W32APIOptions.DEFAULT_OPTIONS);
 
   short GetKeyState(int vKey);
-  
+
   int GetKeyboardLayout(int dwLayout);
-  
+
   int MapVirtualKeyExW (int uCode, int nMapType, int dwhkl);
+  int MapVirtualKeyW(int uCode, int uMapType);
 
   boolean GetKeyboardState(byte[] lpKeyState);
 
   int ToUnicodeEx(int wVirtKey, int wScanCode, byte[] lpKeyState, char[] pwszBuff, int cchBuff, int wFlags, int dwhkl);
-  
+
+  void keybd_event(byte bVk, byte bScan, DWORD dwFlags, ULONG_PTR dwExtraInfo);
+
 }
 

--- a/API/src/main/java/org/sikuli/script/support/KeyboardLayout.java
+++ b/API/src/main/java/org/sikuli/script/support/KeyboardLayout.java
@@ -17,7 +17,7 @@ public class KeyboardLayout {
   private static final Map<Character, int[]> DEFAULT_KEYBOARD_LAYOUT = buildAwtEnUs(); // en-US;
 
   private static final Map<Integer, Map<Character, int[]>> LAYOUTS = new HashMap<>();
-  
+
   class WindowsVkCodes {
     public static final int VK_SHIFT = 0x10; // SHIFT key
     public static final int VK_CONTROL = 0x11; // CTRL key
@@ -314,7 +314,7 @@ public class KeyboardLayout {
     layout.putAll(mapKeyCodes(new int[] { WindowsVkCodes.VK_CONTROL, WindowsVkCodes.VK_MENU }, keyboarLayoutId));
     layout.putAll(mapKeyCodes(new int[] { WindowsVkCodes.VK_SHIFT }, keyboarLayoutId));
     layout.putAll(mapKeyCodes(new int[0], keyboarLayoutId));
-    
+
     // Modifier
     layout.put(Key.C_SHIFT, new int[] { WindowsVkCodes.VK_SHIFT });
     layout.put(Key.C_CTRL, new int[] { WindowsVkCodes.VK_CONTROL });
@@ -374,7 +374,7 @@ public class KeyboardLayout {
     layout.put(Key.C_MULTIPLY, new int[] { WindowsVkCodes.VK_MULTIPLY });
     layout.put(Key.C_DIVIDE, new int[] { WindowsVkCodes.VK_DIVIDE });
     layout.put(Key.C_DECIMAL, new int[] { WindowsVkCodes.VK_DECIMAL });
-    layout.put(Key.C_CONTEXT, new int[] { WindowsVkCodes.VK_APPS });    
+    layout.put(Key.C_CONTEXT, new int[] { WindowsVkCodes.VK_APPS });
     layout.put(Key.C_WIN, new int[] { WindowsVkCodes.VK_LWIN });
     // hack: alternative tab in GUI
     layout.put(Key.C_NEXT, new int[] { -WindowsVkCodes.VK_TAB });
@@ -582,7 +582,7 @@ public class KeyboardLayout {
   private static Map<Character, int[]> getCurrentLayout() {
     Map<Character, int[]> layout = DEFAULT_KEYBOARD_LAYOUT;
 
-    if (Settings.AutoDetectKeyboardLayout && Settings.isWindows()) {
+    if (isWindowsAutoDetect()) {
       int keyboarLayoutId = DEFAULT_KEYBOARD_LAYOUT_ID;
       HWND hwnd = SXUser32.INSTANCE.GetForegroundWindow();
       if (hwnd != null) {
@@ -590,14 +590,20 @@ public class KeyboardLayout {
         keyboarLayoutId = SXUser32.INSTANCE.GetKeyboardLayout(threadID);
       }
 
-      layout = LAYOUTS.get(keyboarLayoutId);
+      synchronized(LAYOUTS) {
+        layout = LAYOUTS.get(keyboarLayoutId);
 
-      if (layout == null) {
-        layout = buildWindowsLayout(keyboarLayoutId);
-        LAYOUTS.put(keyboarLayoutId, layout);
+        if (layout == null) {
+          layout = buildWindowsLayout(keyboarLayoutId);
+          LAYOUTS.put(keyboarLayoutId, layout);
+        }
       }
     }
     return layout;
+  }
+
+  public static boolean isWindowsAutoDetect() {
+    return Settings.AutoDetectKeyboardLayout && Settings.isWindows();
   }
 
   public static int[] toJavaKeyCode(char c) {

--- a/API/src/main/java/org/sikuli/script/support/KeyboardLayout.java
+++ b/API/src/main/java/org/sikuli/script/support/KeyboardLayout.java
@@ -599,8 +599,6 @@ public class KeyboardLayout {
             LAYOUTS.put(keyboardLayoutId, layout);
           }
         }
-      } else {
-        layout = DEFAULT_KEYBOARD_LAYOUT;
       }
     }
     return layout;

--- a/API/src/main/java/org/sikuli/script/support/KeyboardLayout.java
+++ b/API/src/main/java/org/sikuli/script/support/KeyboardLayout.java
@@ -583,20 +583,24 @@ public class KeyboardLayout {
     Map<Character, int[]> layout = DEFAULT_KEYBOARD_LAYOUT;
 
     if (isWindowsAutoDetect()) {
-      int keyboarLayoutId = DEFAULT_KEYBOARD_LAYOUT_ID;
+      int keyboardLayoutId = DEFAULT_KEYBOARD_LAYOUT_ID;
       HWND hwnd = SXUser32.INSTANCE.GetForegroundWindow();
       if (hwnd != null) {
         int threadID = SXUser32.INSTANCE.GetWindowThreadProcessId(hwnd, null);
-        keyboarLayoutId = SXUser32.INSTANCE.GetKeyboardLayout(threadID);
+        keyboardLayoutId = SXUser32.INSTANCE.GetKeyboardLayout(threadID);
       }
 
-      synchronized(LAYOUTS) {
-        layout = LAYOUTS.get(keyboarLayoutId);
+      if(keyboardLayoutId > 0) {
+        synchronized(LAYOUTS) {
+          layout = LAYOUTS.get(keyboardLayoutId);
 
-        if (layout == null) {
-          layout = buildWindowsLayout(keyboarLayoutId);
-          LAYOUTS.put(keyboarLayoutId, layout);
+          if (layout == null) {
+            layout = buildWindowsLayout(keyboardLayoutId);
+            LAYOUTS.put(keyboardLayoutId, layout);
+          }
         }
+      } else {
+        layout = DEFAULT_KEYBOARD_LAYOUT;
       }
     }
     return layout;


### PR DESCRIPTION
Had to separate Windows and AWT keyboard events because the current implementation caused some key events getting lost. Furthermore it was necessary to make keyboard layout generation thread safe.