### PR TITLE
Implement code normalization for Jython runLines

### DIFF
--- a/API/src/main/java/org/sikuli/script/runners/JythonRunner.java
+++ b/API/src/main/java/org/sikuli/script/runners/JythonRunner.java
@@ -4,15 +4,12 @@
 package org.sikuli.script.runners;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.PrintStream;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Stack;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -155,7 +152,7 @@ public class JythonRunner extends AbstractLocalFileScriptRunner {
     return String.join("\n", lines) + "\n";
   }
 
-  private static final Pattern COMMENT_PATTERN = Pattern.compile("^\\s*#.*");
+  private static final Pattern COMMENT_PATTERN = Pattern.compile("\\s*#.*");
 
   private List<String> stripComments(List<String> lines) {
     return lines.stream().filter((line) -> !COMMENT_PATTERN.matcher(line).matches()).collect(Collectors.toList());
@@ -238,24 +235,24 @@ public class JythonRunner extends AbstractLocalFileScriptRunner {
       String startExpression, String indentation) {
     lines = new ArrayList<>(lines);
 
-    Stack<Integer> lineNumbers = new Stack<>();
-    Stack<String> lineIndentations = new Stack<>();
+    List<Integer> lineNumbers = new ArrayList<>();
+    List<String> lineIndentations = new ArrayList<>();
 
     for (int lineNumber = lines.size() - 1; lineNumber >= 0; lineNumber--) {
       String line = lines.get(lineNumber);
       if (lineMatches(line, endPatterns)) {
         String lineIndentation = detectIndentation(line);
         if (lineIndentations.isEmpty() || !lineIndentation.equals(lineIndentations.get(0))) {
-          lineNumbers.push(lineNumber);
-          lineIndentations.push(lineIndentation);
+          lineNumbers.add(0, lineNumber);
+          lineIndentations.add(0, lineIndentation);
         } else {
           lineNumbers.set(0, lineNumber);
           lineIndentations.set(0, lineIndentation);
         }
       } else if (lineMatches(line, startPatterns)) {
         if (!lineNumbers.isEmpty()) {
-          lineNumbers.pop();
-          lineIndentations.pop();
+          lineNumbers.remove(0);
+          lineIndentations.remove(0);
         }
       }
     }

--- a/API/src/main/java/org/sikuli/script/runners/JythonRunner.java
+++ b/API/src/main/java/org/sikuli/script/runners/JythonRunner.java
@@ -308,12 +308,7 @@ public class JythonRunner extends AbstractLocalFileScriptRunner {
    * Checks if the given line matches at least one of the given patterns.
    */
   private boolean lineMatches(String line, Pattern[] patterns) {
-    for (Pattern pattern : patterns) {
-      if (pattern.matcher(line).matches()) {
-        return true;
-      }
-    }
-    return false;
+    return Arrays.asList(patterns).stream().anyMatch((pattern) -> pattern.matcher(line).matches());
   }
 
   private static final Pattern INDENTATION_PATTERN = Pattern.compile("(\\s+).+?");

--- a/API/src/main/java/org/sikuli/script/runners/JythonRunner.java
+++ b/API/src/main/java/org/sikuli/script/runners/JythonRunner.java
@@ -7,7 +7,13 @@ import java.io.File;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Stack;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -21,7 +27,6 @@ import org.sikuli.script.Sikulix;
 import org.sikuli.script.runnerHelpers.JythonHelper;
 import org.sikuli.script.support.IScriptRunner;
 import org.sikuli.script.support.RunTime;
-import org.sikuli.script.support.Runner;
 import org.sikuli.util.InterruptibleThreadRunner;
 
 /**
@@ -105,20 +110,12 @@ public class JythonRunner extends AbstractLocalFileScriptRunner {
     // Since we have a static interpreter, we have to synchronize class wide
     synchronized (JythonRunner.class) {
       threadRunner.run(options.getTimeout(), () -> {
-        final String execLines;
+        final String normalizedLines = normalizePartialScript(lines);
 
-        if (lines.contains("\n")) {
-          if (lines.startsWith(" ") || lines.startsWith("\t")) {
-            execLines = "if True:\n" + lines;
-          } else {
-            execLines = lines;
-          }
-        } else {
-          execLines = lines;
-        }
+        executeScriptHeader();
 
         try {
-          interpreter.exec(execLines);
+          interpreter.exec(normalizedLines);
           return 0;
         } catch (Exception ex) {
           log(-1, "runPython: (%s) raised: %s", lines, ex);
@@ -126,6 +123,219 @@ public class JythonRunner extends AbstractLocalFileScriptRunner {
         }
       });
     }
+  }
+
+  private static final Pattern[] IF_START_PATTERNS = new Pattern[] { Pattern.compile("\\s*if.*:\\s*") };
+
+  private static final Pattern[] IF_END_PATTERNS = new Pattern[] { Pattern.compile("\\s*elif.*:\\s*"),
+      Pattern.compile("\\s*else\\s*:\\s*") };
+
+  private static final Pattern[] TRY_START_PATTERNS = new Pattern[] { Pattern.compile("\\s*try\\s*:\\s*") };
+
+  private static final Pattern[] TRY_END_PATTERNS = new Pattern[] { Pattern.compile("\\s*except.*:\\s*"),
+      Pattern.compile("\\s*finally\\s*:\\s*") };
+
+  /*
+   * Normalizes a partial script passed to runLines.
+   */
+  private String normalizePartialScript(String script) {
+    List<String> lines = getLines(script);
+
+    lines = stripComments(lines);
+    lines = normalizeIndentation(lines);
+
+    String indentation = detectIndentation(script);
+    lines = fixLastLine(lines, indentation);
+    lines = fixUnclosedTryBlock(lines, indentation);
+    lines = fixUnopenedBlock(lines, TRY_START_PATTERNS, TRY_END_PATTERNS, "try:", indentation);
+    lines = fixUnopenedBlock(lines, IF_START_PATTERNS, IF_END_PATTERNS, "if True:", indentation);
+
+    return String.join("\n", lines) + "\n";
+  }
+
+  private static final Pattern COMMENT_PATTERN = Pattern.compile("^\\s*#.*");
+
+  private List<String> stripComments(List<String> lines) {
+    return lines.stream().filter((line) -> !COMMENT_PATTERN.matcher(line).matches()).collect(Collectors.toList());
+  }
+
+  /*
+   * Remove unnecessary indentation.
+   *
+   * In the example it removed the first 2 spaces on each line.
+   *
+   * ---
+   *   if True:
+   *     hello("world") ---
+   */
+  private List<String> normalizeIndentation(List<String> lines) {
+    while (true) {
+      for (String line : lines) {
+        if (detectIndentation(line).isEmpty()) {
+          return lines;
+        }
+      }
+
+      lines = lines.stream().map((line) -> line.substring(1)).collect(Collectors.toList());
+    }
+  }
+
+  /*
+   * Fixes for example the following:
+   *
+   * ---
+   * try:
+   *   print("hello")
+   * ---
+   *
+   * Also handle nested tries and adds the required number of excepts with the
+   * corresponding indentation.
+   *
+   */
+  private List<String> fixUnclosedTryBlock(List<String> lines, String indentation) {
+    lines = new ArrayList<>(lines);
+
+    List<String> lineIndentations = new LinkedList<>();
+
+    for (String line : lines) {
+      if (lineMatches(line, TRY_START_PATTERNS)) {
+        lineIndentations.add(detectIndentation(line));
+      } else if (lineMatches(line, TRY_END_PATTERNS)) {
+        if (!lineIndentations.isEmpty()) {
+          String lineIndentation = detectIndentation(line);
+          if (lineIndentation.equals(lineIndentations.get(lineIndentations.size() - 1))) {
+            lineIndentations.remove(lineIndentations.size() - 1);
+          }
+        }
+      }
+    }
+
+    Collections.reverse(lineIndentations);
+
+    for (String lineIndentation : lineIndentations) {
+      lines.add(lineIndentation + "except:");
+      lines.add(lineIndentation + indentation + "raise");
+    }
+
+    return lines;
+  }
+
+  /*
+   * Fixes for example the following:
+   *
+   * ---
+   *     print("foo")
+   *   else print("bar")
+   * except:
+   *   print("error") ---
+   *
+   * Creates the required try or if to get a valid block. Also works with nested
+   * blocks.
+   */
+  private List<String> fixUnopenedBlock(List<String> lines, Pattern[] startPatterns, Pattern[] endPatterns,
+      String startExpression, String indentation) {
+    lines = new ArrayList<>(lines);
+
+    Stack<Integer> lineNumbers = new Stack<>();
+    Stack<String> lineIndentations = new Stack<>();
+
+    for (int lineNumber = lines.size() - 1; lineNumber >= 0; lineNumber--) {
+      String line = lines.get(lineNumber);
+      if (lineMatches(line, endPatterns)) {
+        String lineIndentation = detectIndentation(line);
+        if (lineIndentations.isEmpty() || !lineIndentation.equals(lineIndentations.get(0))) {
+          lineNumbers.push(lineNumber);
+          lineIndentations.push(lineIndentation);
+        }
+      } else if (lineMatches(line, startPatterns)) {
+        if (!lineNumbers.isEmpty()) {
+          lineNumbers.pop();
+          lineIndentations.pop();
+        }
+      }
+    }
+
+    int insertCount = 0;
+
+    for (int i = lineNumbers.size() - 1; i >= 0; i--) {
+      int lineNumber = lineNumbers.get(i) + (insertCount++);
+      String lineIndentation = lineIndentations.get(i);
+
+      int index = 0;
+
+      for (int n = lineNumber - 1; n >= 0; n--) {
+        String line = lines.get(n);
+
+        if (!line.trim().isEmpty() && detectIndentation(line).length() < lineIndentation.length()) {
+          index = n + 1;
+          break;
+        }
+      }
+      String newLine = lineIndentation + startExpression;
+
+      if (index == lineNumber) {
+        newLine += "\n" + lineIndentation + indentation + "pass";
+      }
+
+      lines.add(index, newLine);
+    }
+
+    return lines;
+  }
+
+  /*
+   * Checks if last line is one of the start/end patterns and makes it a valid
+   * statement.
+   */
+  private List<String> fixLastLine(List<String> lines, String indentation) {
+    lines = new ArrayList<>(lines);
+
+    String lastLine = lines.get(lines.size() - 1);
+
+    if (lineMatches(lastLine, TRY_END_PATTERNS)) {
+      lines.add(detectIndentation(lastLine) + indentation + "raise");
+    } else if (lineMatches(lastLine, IF_START_PATTERNS) || lineMatches(lastLine, IF_END_PATTERNS)
+        || lineMatches(lastLine, TRY_START_PATTERNS)) {
+      lines.add(detectIndentation(lastLine) + indentation + "pass");
+    }
+
+    return lines;
+  }
+
+  /*
+   * Checks if the given line matches at least one of the given patterns.
+   */
+  private boolean lineMatches(String line, Pattern[] patterns) {
+    for (Pattern pattern : patterns) {
+      if (pattern.matcher(line).matches()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static final Pattern INDENTATION_PATTERN = Pattern.compile("(\\s+).+?");
+
+  /*
+   * Detects the shortest sequence of whitespaces with length > 0). If there is no
+   * such sequence, it returns an empty String.
+   */
+  private String detectIndentation(String script) {
+    String indentation = "";
+
+    for (String line : getLines(script)) {
+      Matcher m = INDENTATION_PATTERN.matcher(line);
+      if (m.matches()) {
+        if (indentation.isEmpty() || m.group(1).length() < indentation.length()) {
+          indentation = m.group(1);
+        }
+      }
+    }
+    return indentation;
+  }
+
+  private List<String> getLines(String script) {
+    return Arrays.asList(script.split("\n"));
   }
 
   @Override

--- a/API/src/main/java/org/sikuli/script/runners/JythonRunner.java
+++ b/API/src/main/java/org/sikuli/script/runners/JythonRunner.java
@@ -248,9 +248,9 @@ public class JythonRunner extends AbstractLocalFileScriptRunner {
         if (lineIndentations.isEmpty() || !lineIndentation.equals(lineIndentations.get(0))) {
           lineNumbers.push(lineNumber);
           lineIndentations.push(lineIndentation);
-        }else {
-          lineNumbers.set(0,lineNumber);
-          lineIndentations.set(0,lineIndentation);
+        } else {
+          lineNumbers.set(0, lineNumber);
+          lineIndentations.set(0, lineIndentation);
         }
       } else if (lineMatches(line, startPatterns)) {
         if (!lineNumbers.isEmpty()) {

--- a/API/src/main/java/org/sikuli/script/runners/JythonRunner.java
+++ b/API/src/main/java/org/sikuli/script/runners/JythonRunner.java
@@ -4,7 +4,9 @@
 package org.sikuli.script.runners;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -246,6 +248,9 @@ public class JythonRunner extends AbstractLocalFileScriptRunner {
         if (lineIndentations.isEmpty() || !lineIndentation.equals(lineIndentations.get(0))) {
           lineNumbers.push(lineNumber);
           lineIndentations.push(lineIndentation);
+        }else {
+          lineNumbers.set(0,lineNumber);
+          lineIndentations.set(0,lineIndentation);
         }
       } else if (lineMatches(line, startPatterns)) {
         if (!lineNumbers.isEmpty()) {


### PR DESCRIPTION
This PR normalized Python code to make it conveniently running with "run to" / "run from".

It normalizes indentations and completes code blocks to get valid code as much as feasible.

E.g.

```
try:
  if True:
    print("foo")
```
becomes
```
try:
  if True:
    print("foo")
except:
  raise
```
or
```
  else:
    print("foo")
except:
  print("error")
```
becomes
```
try:
  if True:
    pass
  else:
    print("foo")
except:
  print("error")
```
It also handles some edge cases when placing the runTo or runFrom cursor to silly line numbers.
All stuff  works nested and with spaces or tabs.
Later we could do the same optimizations for JRuby and JavaScript as well.

