### PR TITLE
Fix save for tab with empty document.

### DIFF
--- a/IDE/src/main/java/org/sikuli/ide/EditorPane.java
+++ b/IDE/src/main/java/org/sikuli/ide/EditorPane.java
@@ -627,7 +627,7 @@ public class EditorPane extends JTextPane {
     if (caretPosition < getDocument().getLength()) {
       setCaretPosition(caretPosition);
     } else {
-      setCaretPosition(getDocument().getLength() - 1);
+      setCaretPosition(Math.max(0, getDocument().getLength() - 1));
     }
     caretPosition = -1;
   }


### PR DESCRIPTION
Ensures that caret position is at least 0 when restoring caret position in EditorPane#restoreCaretPosition(). Otherwise we get an InvalidIndex Exception when saving an empty document. This happens to me quite often when I open a new tab and save it right away.