### PR TITLE
Runlines suggestions / Formatting in EditorConsolePane

### DIFF
--- a/API/src/main/java/org/sikuli/basics/PreferencesUser.java
+++ b/API/src/main/java/org/sikuli/basics/PreferencesUser.java
@@ -33,7 +33,7 @@ public class PreferencesUser {
   public final static int SIKULI_USER = 2;
   public final static int THUMB_HEIGHT = 50;
   public final static String DEFAULT_CONSOLE_CSS =
-          "body   { font-family:serif; font-size: 12px; }"
+          "body   { font-family:monospace; font-size: 10px}"
                   + ".normal{ color: black; }"
                   + ".debug { color:#505000; }"
                   + ".info  { color: blue; }"

--- a/API/src/main/java/org/sikuli/basics/PreferencesUser.java
+++ b/API/src/main/java/org/sikuli/basics/PreferencesUser.java
@@ -32,8 +32,18 @@ public class PreferencesUser {
   public final static int SCRIPTER = 1;
   public final static int SIKULI_USER = 2;
   public final static int THUMB_HEIGHT = 50;
+
+  // Needed to detect if the user prefs contain the old default value
+  public final static String OLD_DEFAULT_CONSOLE_CSS =
+      "body   { font-family:serif; font-size: 12px; }"
+              + ".normal{ color: black; }"
+              + ".debug { color:#505000; }"
+              + ".info  { color: blue; }"
+              + ".log   { color: #09806A; }"
+              + ".error { color: red; }";
+
   public final static String DEFAULT_CONSOLE_CSS =
-          "body   { font-family:monospace; font-size: 10px}"
+          "body   { font-family:monospace; font-size: 11px; }"
                   + ".normal{ color: black; }"
                   + ".debug { color:#505000; }"
                   + ".info  { color: blue; }"
@@ -430,7 +440,22 @@ public class PreferencesUser {
   }
 
   public String getConsoleCSS() {
-    return pref.get("CONSOLE_CSS", DEFAULT_CONSOLE_CSS);
+    String css = pref.get("CONSOLE_CSS", DEFAULT_CONSOLE_CSS);
+
+    /*
+     *  Hack to detect if the user prefs contain the old default
+     *  value.
+     *  In such a case, the new style is forced.
+     *
+     *  TODO: Ensure that the user prefs do not contain default
+     *  values. Having them in prefs makes it really cumbersome
+     *  to change them afterwards.
+     */
+    if (OLD_DEFAULT_CONSOLE_CSS.equals(css)) {
+      css = DEFAULT_CONSOLE_CSS;
+    }
+
+    return css;
   }
 
   // ***** general setter getter

--- a/IDE/src/main/java/org/sikuli/ide/EditorConsolePane.java
+++ b/IDE/src/main/java/org/sikuli/ide/EditorConsolePane.java
@@ -208,8 +208,8 @@ public class EditorConsolePane extends JPanel implements Runnable {
       if (m.matches()) {
         cls = m.group(1);
       }
-      line = "<span class='" + cls + "'>" + line + "</span>";
-      sb.append(line).append("<br>");
+      line = "<pre class=\"" + cls + "\" style=\"margin: 0;\">" + line + "</pre>";
+      sb.append(line);
     }
     return sb.toString();
   }

--- a/IDE/src/main/java/org/sikuli/ide/EditorConsolePane.java
+++ b/IDE/src/main/java/org/sikuli/ide/EditorConsolePane.java
@@ -202,9 +202,11 @@ public class EditorConsolePane extends JPanel implements Runnable {
     StringBuilder sb = new StringBuilder();
     Pattern patMsgCat = Pattern.compile("\\[(.+?)\\].*");
     msg = msg.replace("&", "&amp;").replace("<", "&lt;").replace(">","&gt;");
+    
+    String cls = "normal";
+    
     for (String line : msg.split(lineSep)) {
-      Matcher m = patMsgCat.matcher(line);
-      String cls = "normal";
+      Matcher m = patMsgCat.matcher(line);      
       if (m.matches()) {
         cls = m.group(1);
       }

--- a/IDE/src/main/java/org/sikuli/ide/EditorPane.java
+++ b/IDE/src/main/java/org/sikuli/ide/EditorPane.java
@@ -1665,8 +1665,10 @@ public class EditorPane extends JTextPane {
           ide.setCurrentRunner(editorPane.editorPaneRunner);
           ide.setCurrentScript(editorPane.getCurrentFile());
           ide.setIsRunningScript(true);
+          ide.clearMessageArea();
+          ide.resetErrorMark();
 
-          editorPane.editorPaneRunner.runLines(lines, null);          
+          editorPane.editorPaneRunner.runLines(lines, null);
         } finally {
           SikulixIDE.showAgain();
           ide.setCurrentRunner(null);


### PR DESCRIPTION
This PR implements the suggestions from PR #150 .

Further it clears the console and resets the error line before runLines.

During implementation (of the normalize feature) I noticed that EditorConsolePane does not play nicely with preformatted text. For example it eats up multiple spaces. This due to the fact that it basically uses HTML span elements to present the log messages. I changed the span to pre and the font-family to monospace. Looks much more like a console now :-)

Before:
![image](https://user-images.githubusercontent.com/1055447/60392308-68ad3d80-9b00-11e9-95aa-05749e22810d.png)

After:
![image](https://user-images.githubusercontent.com/1055447/60392313-7367d280-9b00-11e9-8f58-5526a2841857.png)
