### PR TITLE
Fixes -r startup not to detach anymore

### DIFF
--- a/API/src/main/java/org/sikuli/script/support/ExtensionManager.java
+++ b/API/src/main/java/org/sikuli/script/support/ExtensionManager.java
@@ -135,7 +135,7 @@ public class ExtensionManager {
       method.invoke(ClassLoader.getSystemClassLoader(), new Object[]{url});
       method.setAccessible(false);
     } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-      e.printStackTrace();
+      Debug.error("Adding URL %s to class path failed: %s", url.toString(), e.getMessage());
     }
   }
 

--- a/API/src/main/java/org/sikuli/script/support/ExtensionManager.java
+++ b/API/src/main/java/org/sikuli/script/support/ExtensionManager.java
@@ -9,7 +9,10 @@ import org.sikuli.script.runners.ProcessRunner;
 
 import javax.swing.*;
 import java.io.*;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
@@ -122,6 +125,18 @@ public class ExtensionManager {
       }
     }
     return classPath;
+  }
+
+  public static void addClassPathURL(URL url) {
+    Method method;
+    try {
+      method = URLClassLoader.class.getDeclaredMethod("addURL", new Class[]{URL.class});
+      method.setAccessible(true);
+      method.invoke(ClassLoader.getSystemClassLoader(), new Object[]{url});
+      method.setAccessible(false);
+    } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+      e.printStackTrace();
+    }
   }
 
   private static String classPath = "";

--- a/API/src/main/java/org/sikuli/script/support/RunTime.java
+++ b/API/src/main/java/org/sikuli/script/support/RunTime.java
@@ -110,28 +110,39 @@ public class RunTime {
       RunTime.startLog(1, "Classpath: %s", classPath);
     }
 
-    List<String> cmd = new ArrayList<>();
-    cmd.add("java");
-    cmd.add("-Dfile.encoding=UTF-8");
-    if (startAsIDE) {
-      cmd.add("-Dsikuli.IDE_should_run");
-    } else {
-      cmd.add("-Dsikuli.API_should_run");
-    }
-    if (!classPath.isEmpty()) {
-      cmd.add("-cp");
-      cmd.add(classPath);
-    }
-    if (startAsIDE) {
-      cmd.add("org.sikuli.ide.SikulixIDE");
-    } else {
-      cmd.add("org.sikuli.script.support.SikulixAPI");
-    }
-    cmd.addAll(Arrays.asList(args));
-    ProcessRunner.detach(cmd);
-    RunTime.startLog(3, "*********************** leaving start");
-    System.exit(0);
+    if (shouldDetach()) {
+      List<String> cmd = new ArrayList<>();
+      cmd.add("java");
+      cmd.add("-Dfile.encoding=UTF-8");
+      if (startAsIDE) {
+        cmd.add("-Dsikuli.IDE_should_run");
+      } else {
+        cmd.add("-Dsikuli.API_should_run");
+      }
+      if (!classPath.isEmpty()) {
+        cmd.add("-cp");
+        cmd.add(classPath);
+      }
+      if (startAsIDE) {
+        cmd.add("org.sikuli.ide.SikulixIDE");
+      } else {
+        cmd.add("org.sikuli.script.support.SikulixAPI");
+      }
+      cmd.addAll(Arrays.asList(args));
 
+      ProcessRunner.detach(cmd);
+      RunTime.startLog(3, "*********************** leaving start");
+      System.exit(0);
+    } else {
+      String[] classPathFiles = classPath.split(";");
+      for (String file : classPathFiles) {
+        try {
+          ExtensionManager.addClassPathURL(new File(file).toURI().toURL());
+        } catch (MalformedURLException e) {
+          e.printStackTrace();
+        }
+      }
+    }
   }
 
   private static File getRunningJar(Type type) {
@@ -340,12 +351,7 @@ public class RunTime {
     }
 
     if (cmdLineValid && cmdLine.hasOption("s")) {
-      asServer = true;
       serverOptions = cmdLine.getOptionValues("s");
-    }
-
-    if (cmdLineValid && cmdLine.hasOption("p")) {
-      asPyServer = true;
     }
 
     if (cmdLineValid && cmdLine.hasOption("m")) {
@@ -456,6 +462,12 @@ public class RunTime {
         setVerbose();
       } else if ("-q".equals(arg)) {
         setQuiet();
+      } else if ("-r".equals(arg)) {
+        shouldRunScript = true;
+      } else if ("-s".equals(arg)) {
+        asServer = true;
+      }  else if ("-p".equals(arg)) {
+        asPyServer = true;
       }
     }
   }
@@ -540,10 +552,11 @@ public class RunTime {
     return runScripts;
   }
 
+  private static boolean shouldRunScript = false;
   private static String[] runScripts = new String[0];
 
   public static boolean runningScripts() {
-    return runScripts.length > 0;
+    return shouldRunScript;
   }
 
   public static boolean shouldRunServer() {
@@ -585,6 +598,10 @@ public class RunTime {
   }
 
   private static boolean allowMultiple = false;
+
+  public static boolean shouldDetach() {
+    return !runningScripts() && !shouldRunServer() && !shouldRunPythonServer();
+  }
 
   public static File getAppPath() {
     if (null != sxAppPath) {

--- a/API/src/main/java/org/sikuli/script/support/RunTime.java
+++ b/API/src/main/java/org/sikuli/script/support/RunTime.java
@@ -139,7 +139,7 @@ public class RunTime {
         try {
           ExtensionManager.addClassPathURL(new File(file).toURI().toURL());
         } catch (MalformedURLException e) {
-          e.printStackTrace();
+          Debug.error("Getting URL for class path file %s failed: %s", file, e.getMessage());
         }
       }
     }

--- a/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
+++ b/IDE/src/main/java/org/sikuli/ide/SikulixIDE.java
@@ -51,10 +51,9 @@ public class SikulixIDE extends JFrame {
           SikulixIDE.class.getResource("/icons/sikulix.png"));
 
   public static void main(String[] args) {
+    RunTime.afterStart(RunTime.Type.IDE, args);
 
     IDETaskbarSupport.setTaksIcon(ICON_IMAGE);
-
-    RunTime.afterStart(RunTime.Type.IDE, args);
 
     if ("m".equals(System.getProperty("os.name").substring(0, 1).toLowerCase())) {
       prepareMacUI();


### PR DESCRIPTION
Commit 7801e9adf871a80a2711e3d7a56250998808e4f7 broke running with -r because RunTime.start  now really detached the newly created process.

This PR change script / server startup that it is no longer necessary to spawn a separate process for it. Instead it adds the jar files to the class loader using reflection.