### PR TITLE
Optimizes PatternWindow size to the aspect ratio of the screen

### DIFF
--- a/IDE/src/main/java/org/sikuli/ide/PatternPaneScreenshot.java
+++ b/IDE/src/main/java/org/sikuli/ide/PatternPaneScreenshot.java
@@ -18,7 +18,7 @@ import org.sikuli.script.support.ScreenUnion;
 import org.sikuli.basics.Debug;
 
 class PatternPaneScreenshot extends JPanel implements ChangeListener, ComponentListener {
-
+  public static final int BOTTOM_MARGIN = 200;
   private static final String me = "PatternPaneScreenshot: ";
   static int DEFAULT_H;
   static int MAX_NUM_MATCHING = EditorPatternButton.DEFAULT_NUM_MATCHES;
@@ -53,7 +53,7 @@ class PatternPaneScreenshot extends JPanel implements ChangeListener, ComponentL
     _msgApplied = msgApplied;
     _match_region = new ScreenUnion();
     _ratio = (double) _match_region.w / _match_region.h;
-    _height = pDim.height - 200;
+    _height = pDim.height - BOTTOM_MARGIN;
     _scale = (double) _height / _match_region.h;
     _width = (int) (_match_region.w * _scale);
     setPreferredSize(new Dimension(_width, _height));

--- a/IDE/src/main/java/org/sikuli/ide/PatternWindow.java
+++ b/IDE/src/main/java/org/sikuli/ide/PatternWindow.java
@@ -68,8 +68,16 @@ public class PatternWindow extends JFrame {
       pDim = getGraphicsConfiguration().getBounds().getSize();
       pDim.width = (int) ((pDim.width - 2 * pOff) * 0.95);
       pDim.height = (int) ((pDim.height - 2 * pOff) * 0.95);
+
+      // optimize window size to aspect ratio of screenshot
+      double ratio = (double) _simg.w / _simg.h;
+      pDim.width = Math.min((int) ((pDim.height - PatternPaneScreenshot.BOTTOM_MARGIN) * ratio), pDim.width);
+
+      // center window
       pLoc = getGraphicsConfiguration().getBounds().getLocation();
-      pLoc.translate(pOff, pOff);
+      int offsetX = (getGraphicsConfiguration().getBounds().getSize().width - pDim.width) / 2;
+      int offsetY = (getGraphicsConfiguration().getBounds().getSize().height - pDim.height) / 2;
+      pLoc.translate(offsetX, offsetY);
     }
     setPreferredSize(pDim);
 


### PR DESCRIPTION
At some screen resolutions (e.g. 16:10) the bottom part of the preview screenshot is always cut off. If one would like to see this part one has to manually resize the PatternWindow that the screenshot gets scaled to a smaller height.

This PR optimizes the PattenWindow size beforehand that the whole screeshot fits into the panel.

Furthermore it centers the window on the screen.

