### PR TITLE
Revert failed class path extension experiment to "new process" solution

### DIFF
--- a/API/src/main/java/org/sikuli/script/runners/ProcessRunner.java
+++ b/API/src/main/java/org/sikuli/script/runners/ProcessRunner.java
@@ -168,6 +168,32 @@ public class ProcessRunner extends AbstractScriptRunner{
     }
   }
 
+  public static int runBlocking(List<String> cmd) {
+    int exitValue = 0;
+    if (cmd.size() > 0) {
+      ProcessBuilder app = new ProcessBuilder();
+      app.command(cmd);
+      app.redirectInput(ProcessBuilder.Redirect.INHERIT);
+      app.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+      Process process = null;
+      try {
+        process = app.start();
+      } catch (Exception e) {
+        p("[Error] ProcessRunner: start: %s", e.getMessage());
+      }
+
+      try {
+        if (process != null) {
+          process.waitFor();
+          exitValue = process.exitValue();
+        }
+      } catch (InterruptedException e) {
+        p("[Error] ProcessRunner: waitFor: %s", e.getMessage());
+      }
+    }
+    return exitValue;
+  }
+
   public static int startApp(String... givenCmd) {
     List<String> cmd = new ArrayList<>();
     cmd.addAll(Arrays.asList(givenCmd));

--- a/API/src/main/java/org/sikuli/script/support/ExtensionManager.java
+++ b/API/src/main/java/org/sikuli/script/support/ExtensionManager.java
@@ -127,18 +127,6 @@ public class ExtensionManager {
     return classPath;
   }
 
-  public static void addClassPathURL(URL url) {
-    Method method;
-    try {
-      method = URLClassLoader.class.getDeclaredMethod("addURL", new Class[]{URL.class});
-      method.setAccessible(true);
-      method.invoke(ClassLoader.getSystemClassLoader(), new Object[]{url});
-      method.setAccessible(false);
-    } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-      Debug.error("Adding URL %s to class path failed: %s", url.toString(), e.getMessage());
-    }
-  }
-
   private static String classPath = "";
 
   public static void readExtensions(boolean afterStart) {

--- a/API/src/main/java/org/sikuli/script/support/RunTime.java
+++ b/API/src/main/java/org/sikuli/script/support/RunTime.java
@@ -110,38 +110,32 @@ public class RunTime {
       RunTime.startLog(1, "Classpath: %s", classPath);
     }
 
-    if (shouldDetach()) {
-      List<String> cmd = new ArrayList<>();
-      cmd.add("java");
-      cmd.add("-Dfile.encoding=UTF-8");
-      if (startAsIDE) {
-        cmd.add("-Dsikuli.IDE_should_run");
-      } else {
-        cmd.add("-Dsikuli.API_should_run");
-      }
-      if (!classPath.isEmpty()) {
-        cmd.add("-cp");
-        cmd.add(classPath);
-      }
-      if (startAsIDE) {
-        cmd.add("org.sikuli.ide.SikulixIDE");
-      } else {
-        cmd.add("org.sikuli.script.support.SikulixAPI");
-      }
-      cmd.addAll(Arrays.asList(args));
+    List<String> cmd = new ArrayList<>();
+    cmd.add("java");
+    cmd.add("-Dfile.encoding=UTF-8");
+    if (startAsIDE) {
+      cmd.add("-Dsikuli.IDE_should_run");
+    } else {
+      cmd.add("-Dsikuli.API_should_run");
+    }
+    if (!classPath.isEmpty()) {
+      cmd.add("-cp");
+      cmd.add(classPath);
+    }
+    if (startAsIDE) {
+      cmd.add("org.sikuli.ide.SikulixIDE");
+    } else {
+      cmd.add("org.sikuli.script.support.SikulixAPI");
+    }
+    cmd.addAll(Arrays.asList(args));
 
+    if (shouldDetach()) {
       ProcessRunner.detach(cmd);
       RunTime.startLog(3, "*********************** leaving start");
       System.exit(0);
     } else {
-      String[] classPathFiles = classPath.split(";");
-      for (String file : classPathFiles) {
-        try {
-          ExtensionManager.addClassPathURL(new File(file).toURI().toURL());
-        } catch (MalformedURLException e) {
-          Debug.error("Getting URL for class path file %s failed: %s", file, e.getMessage());
-        }
-      }
+      int exitCode = ProcessRunner.runBlocking(cmd);
+      System.exit(exitCode);
     }
   }
 


### PR DESCRIPTION
See #169.

Dynamically extending the class path using reflection just does not work out in newer JDKs.

Revert it back to the "new process" solution for now, until we have a working, better solution.

At least in the new version the parent process now waits for termination of its child in case of -r, -s, -p :-)