### PR TITLE
Move .class file check to IDE

### DIFF
--- a/API/src/main/java/org/sikuli/script/runners/ZipRunner.java
+++ b/API/src/main/java/org/sikuli/script/runners/ZipRunner.java
@@ -111,7 +111,7 @@ public class ZipRunner extends AbstractLocalFileScriptRunner {
     } catch (IOException e) {
       log(-1, "Error opening file %s: %s", zipFile, e.getMessage());
     }
-    if (null != innerScriptFilePath && !innerScriptFilePath.endsWith(".class")) {
+    if (null != innerScriptFilePath) {
       return new EffectiveRunner(Runner.getRunner(innerScriptFilePath), innerScriptFilePath, null);
     }
     return new EffectiveRunner();

--- a/IDE/src/main/java/org/sikuli/ide/EditorPane.java
+++ b/IDE/src/main/java/org/sikuli/ide/EditorPane.java
@@ -317,6 +317,11 @@ public class EditorPane extends JTextPane {
           script = file.getAbsolutePath();
         }
       }
+
+      if (script.endsWith(".class")) {
+        return false;
+      }
+
       editorPaneFileToRun = new File(script);
       editorPaneRunner = runnerAndFile.getRunner();
       editorPaneIsBundle = runnerAndFile.isBundle();


### PR DESCRIPTION
Because of the .class file check in the ZipRunner it is not possible anymore to run .jar files directly using the -r option. ZipRunner simply doesn't return an effective runner in case of the inner script is a $py.class file.

This PR moves this check to the IDE EditorPane.