### PR TITLE
Make Regions mouseMove behaviour identical to hover

### DIFF
--- a/API/src/main/java/org/sikuli/script/Region.java
+++ b/API/src/main/java/org/sikuli/script/Region.java
@@ -3912,11 +3912,7 @@ public class Region {
    * @return 1 if possible, 0 otherwise
    */
   public int hover() {
-    try { // needed to cut throw chain for FindFailed
-      return hover(checkMatch());
-    } catch (FindFailed ex) {
-    }
-    return 0;
+    return mouseMove();
   }
 
   /**
@@ -4257,12 +4253,9 @@ public class Region {
    * @return 1 if possible, 0 otherwise
    */
   public int mouseMove() {
-    if (lastMatch != null) {
-      try {
-        return mouseMove(lastMatch);
-      } catch (FindFailed ex) {
-        return 0;
-      }
+    try { // needed to cut throw chain for FindFailed
+      return mouseMove(checkMatch());
+    } catch (FindFailed ex) {
     }
     return 0;
   }


### PR DESCRIPTION
`wait("img.png").hover()` does work.
`wait("img.png").mouseMove()` does NOT work.

As stated in JavaDoc, those two methods should do the same. The problem with `mouseMove()` is that it only operates on the `lastMatch` while `hover()` (and most of the other mouse methods) use the `checkMatch()` method to also use the current location.

This PR uses the `checkMatch()` method from within `mouseMove()` as well and delegates `hover()` calls to `mouseMove()`.