### PR TITLE
Remove strange import

### DIFF
--- a/API/src/main/java/org/sikuli/script/support/RunTime.java
+++ b/API/src/main/java/org/sikuli/script/support/RunTime.java
@@ -35,8 +35,6 @@ import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import static jdk.internal.joptsimple.internal.Reflection.invoke;
-
 /**
  * INTERNAL USE --- NOT official API<br>
  * not as is in version 2


### PR DESCRIPTION
Did a rebase of master after some SikuliX absence due to other prios and got a compile error.

You know what this import is for? Seems not to be needed and the package does not even exist on my machine.

`import static jdk.internal.joptsimple.internal.Reflection.invoke;`

After removing it, everything compiles again and still seems to work.