### PR TITLE
Remove unnecessary enumWindows in getEnv()

### DIFF
--- a/API/src/main/java/org/sikuli/natives/WinUtil.java
+++ b/API/src/main/java/org/sikuli/natives/WinUtil.java
@@ -208,12 +208,6 @@ public class WinUtil implements OSUtil {
     if (retInt > 0) {
       envVal = new String(Arrays.copyOfRange(retChar, 0, retInt));
     }
-    sxuser32.EnumWindows(new WinUser.WNDENUMPROC() {
-      @Override
-      public boolean callback(WinDef.HWND hwnd, Pointer pointer) {
-        return false;
-      }
-    }, null);
     return envVal;
   }
 


### PR DESCRIPTION
This code was added by commit b43b8bc1afad654e37c8bbe48653b088953035a4.
Feel free to keep it there if there is a reason to enum windows when getting env variables.