### PR TITLE
Better handling of sub pixel rendering (AKA ClearType)

### DIFF
--- a/API/src/main/java/org/sikuli/script/Finder.java
+++ b/API/src/main/java/org/sikuli/script/Finder.java
@@ -667,7 +667,6 @@ public class Finder implements Iterator<Match> {
         TextRecognizer tr = TextRecognizer.start();
         if (tr.isValid()) {
           Tesseract1 tapi = tr.getAPI();
-          tr.setVariable("user_defined_dpi", "" + tr.optimumDPI);
           long timer = new Date().getTime();
           int textLevel = fInput.getTextLevel();
           List<Word> wordsFound = null;

--- a/API/src/main/java/org/sikuli/script/Finder.java
+++ b/API/src/main/java/org/sikuli/script/Finder.java
@@ -671,7 +671,7 @@ public class Finder implements Iterator<Match> {
           long timer = new Date().getTime();
           int textLevel = fInput.getTextLevel();
           List<Word> wordsFound = null;
-          bimgWork = tr.resize(bimg);
+          bimgWork = tr.optimize(bimg);
           boolean singleWord = true;
           String[] textSplit = new String[0];
           java.util.regex.Pattern pattern = null;


### PR DESCRIPTION
Using an unsharp mask to sharpen the image, before and after resizing it, dramatically decreases the error rate.

This even allows to decrease the DPI of the image to increase OCR performance.

Many experiments show, that the combination of a DPI value of 192 and a sigma value of 3 for the first respective 5 for the second `unsharpMask()` gives the best results.

And I moved `setVariable("user_defined_dpi", "" + optimumDPI)` inside the `optimize()` method, so there is no need anymore to call it from the outside. 