### PR TITLE
Better abort implementation for JythonRunner

### DIFF
--- a/API/src/main/java/org/sikuli/script/runnerSupport/JRubySupport.java
+++ b/API/src/main/java/org/sikuli/script/runnerSupport/JRubySupport.java
@@ -198,7 +198,7 @@ public class JRubySupport implements IRunnerSupport {
     }
   }
 
-  public int findErrorSource(Throwable thr, String filename) {
+  public int findErrorSource(Throwable thr, String filename, int headerOffset) {
     String err = thr.getMessage();
 
     errorLine = -1;
@@ -258,7 +258,7 @@ public class JRubySupport implements IRunnerSupport {
     msg = "script";
     if (errorLine != -1) {
       // log(-1,_I("msgErrorLine", srcLine));
-      msg += " stopped with error in line " + errorLine;
+      msg += " stopped with error in line " + (errorLine - headerOffset);
       if (errorColumn != -1) {
         msg += " at column " + errorColumn;
       }
@@ -303,7 +303,7 @@ public class JRubySupport implements IRunnerSupport {
       Debug.error("Could not evaluate error source nor reason. Analyze StackTrace!");
       Debug.error(err);
     }
-    return errorLine;
+    return errorLine - headerOffset;
   }
 
   private int errorLine;

--- a/API/src/main/java/org/sikuli/script/runners/AbstractScriptRunner.java
+++ b/API/src/main/java/org/sikuli/script/runners/AbstractScriptRunner.java
@@ -52,6 +52,7 @@ public abstract class AbstractScriptRunner implements IScriptRunner {
   private static volatile Thread worker = null;
   private static final ScheduledExecutorService TIMEOUT_EXECUTOR = Executors.newSingleThreadScheduledExecutor();
   private static final Object WORKER_LOCK = new Object();
+  private static boolean aborted = false;
 
   protected void log(int level, String message, Object... args) {
     Debug.logx(level, getName() + "Runner: " + message, args);
@@ -273,31 +274,37 @@ public abstract class AbstractScriptRunner implements IScriptRunner {
   }
 
   public final void abort() {
-    if (running && isAbortSupported()) {
-      doAbort();
-    }
-  }
-
-  protected void doAbort() {
     synchronized (WORKER_LOCK) {
-      if (worker != null) {
-          worker.interrupt();
+      if (running && isAbortSupported()) {
+        aborted = true;
+        doAbort();
       }
     }
   }
 
+  protected void doAbort() {
+    if (worker != null) {
+        worker.interrupt();
+    }
+  }
+
+  public static boolean isAborted() {
+    synchronized (WORKER_LOCK) {
+      return aborted;
+    }
+  }
+
   private int runAbortable(IScriptRunner.Options options, IntSupplier block) {
+    boolean newWorker;
+    IntByReference exitCode = new IntByReference(1);
+
     synchronized (WORKER_LOCK) {
       if (Thread.currentThread().isInterrupted()) {
         Debug.log(-1, "%s thread interrupted.", getName());
         return 1;
       }
-    }
 
-    boolean newWorker;
-    IntByReference exitCode = new IntByReference(1);
-
-    synchronized (WORKER_LOCK) {
+      aborted = false;
       newWorker = worker == null;
 
       if (newWorker) {

--- a/API/src/main/java/org/sikuli/script/runners/AbstractScriptRunner.java
+++ b/API/src/main/java/org/sikuli/script/runners/AbstractScriptRunner.java
@@ -162,7 +162,7 @@ public abstract class AbstractScriptRunner implements IScriptRunner {
   @Override
   public final int runScript(String script, String[] scriptArgs, IScriptRunner.Options maybeOptions) {
     IScriptRunner.Options options = null != maybeOptions ? maybeOptions : new IScriptRunner.Options();
-    
+
     return runSynchronized(options, () -> {
       int savedLevel = Debug.getDebugLevel();
       if (!Debug.isGlobalDebug()) {
@@ -278,13 +278,10 @@ public abstract class AbstractScriptRunner implements IScriptRunner {
     }
   }
 
-  @SuppressWarnings("deprecation")
   protected void doAbort() {
-
     synchronized (WORKER_LOCK) {
       if (worker != null) {
           worker.interrupt();
-          worker.stop();
       }
     }
   }

--- a/API/src/main/java/org/sikuli/script/runners/JRubyRunner.java
+++ b/API/src/main/java/org/sikuli/script/runners/JRubyRunner.java
@@ -79,6 +79,10 @@ public class JRubyRunner extends AbstractLocalFileScriptRunner {
          + "}\n" + script;
   }
 
+  private int injectAbortWatcherLineCount() {
+    return injectAbortWatcher("").split("\n").length;
+  }
+
   //<editor-fold desc="10 run scripts">
   @Override
   protected int doRunScript(String scriptFile, String[] scriptArgs, IScriptRunner.Options options) {
@@ -118,7 +122,7 @@ public class JRubyRunner extends AbstractLocalFileScriptRunner {
           } else {
             //TODO to be optimized (avoid double message)
             int errorExit = jrubySupport.findErrorSource(scriptException, rubyFile.getAbsolutePath());
-            options.setErrorLine(errorExit);
+            options.setErrorLine(errorExit - injectAbortWatcherLineCount());
           }
         }
       }

--- a/API/src/main/java/org/sikuli/script/runners/JRubyRunner.java
+++ b/API/src/main/java/org/sikuli/script/runners/JRubyRunner.java
@@ -121,8 +121,8 @@ public class JRubyRunner extends AbstractLocalFileScriptRunner {
             Debug.info("Exit code: " + exitCode);
           } else {
             //TODO to be optimized (avoid double message)
-            int errorExit = jrubySupport.findErrorSource(scriptException, rubyFile.getAbsolutePath());
-            options.setErrorLine(errorExit - injectAbortWatcherLineCount());
+            int errorExit = jrubySupport.findErrorSource(scriptException, rubyFile.getAbsolutePath(), injectAbortWatcherLineCount());
+            options.setErrorLine(errorExit);
           }
         }
       }

--- a/API/src/main/java/org/sikuli/script/runners/JavaScriptRunner.java
+++ b/API/src/main/java/org/sikuli/script/runners/JavaScriptRunner.java
@@ -69,17 +69,19 @@ public class JavaScriptRunner extends AbstractLocalFileScriptRunner {
     try {
       engine.eval(new FileReader(new File(scriptFile)));
     } catch (FileNotFoundException | ScriptException e) {
-      log(lvl, "runScript failed", e);
+      if(!isAborted()) {
+        log(lvl, "runScript failed", e);
 
-      if (null != stderr) {
-        stderr.print(e);
+        if (null != stderr) {
+          stderr.print(e);
+        }
+
+        if (null != options) {
+          options.setErrorLine(findErrorSource(e, scriptFile));
+        }
+
+        return -1;
       }
-
-      if (null != options) {
-        options.setErrorLine(findErrorSource(e, scriptFile));
-      }
-
-      return -1;
     }
     return 0;
   }
@@ -96,17 +98,19 @@ public class JavaScriptRunner extends AbstractLocalFileScriptRunner {
     try {
       engine.eval(script);
     } catch (ScriptException e) {
-      log(lvl, "evalScript failed", e);
+      if(!isAborted()) {
+        log(lvl, "evalScript failed", e);
 
-      if (null != stderr) {
-        stderr.print(e);
+        if (null != stderr) {
+          stderr.print(e);
+        }
+
+        if (null != options) {
+          options.setErrorLine(findErrorSource(e, null));
+        }
+
+        exitValue = -1;
       }
-
-      if (null != options) {
-        options.setErrorLine(findErrorSource(e, null));
-      }
-
-      exitValue = -1;
     }
     if (silent) {
       Debug.quietOff();

--- a/API/src/main/java/org/sikuli/script/runners/JythonRunner.java
+++ b/API/src/main/java/org/sikuli/script/runners/JythonRunner.java
@@ -25,11 +25,6 @@ public class JythonRunner extends AbstractLocalFileScriptRunner {
   public static final String TYPE = "text/jython";
   public static final String[] EXTENSIONS = new String[]{"py"};
 
-  @SuppressWarnings("serial")
-  public class AbortedException extends RuntimeException{
-
-  }
-
   private static RunTime runTime = RunTime.get();
 
   private int lvl = 3;
@@ -91,7 +86,6 @@ public class JythonRunner extends AbstractLocalFileScriptRunner {
       jythonSupport.showSysPath();
       jythonSupport.interpreterExecString("import sys");
       jythonSupport.interpreterExecString("import org.sikuli.script.support.Runner as Runner");
-      jythonSupport.interpreterExecString("import org.sikuli.script.runners.JythonRunner as JythonRunner");
       String interpreterVersion = jythonSupport.interpreterEval("sys.version.split(\"(\")[0]\n").toString();
       if (interpreterVersion.isEmpty()) {
         interpreterVersion = "could not be evaluated";
@@ -106,7 +100,7 @@ public class JythonRunner extends AbstractLocalFileScriptRunner {
     jythonSupport.interpreterExecString("runner = Runner.getRunner(\"" + NAME + "\")\n"
                                       + "def trace_calls_for_abort(frame, evt, arg):\n"
                                       + "  if runner.isAborted():\n"
-                                      + "    raise JythonRunner.AbortedException(None)\n"
+                                      + "    raise RuntimeError(\"Aborted\")\n"
                                       + "  return trace_calls_for_abort\n"
                                       + "sys.settrace(trace_calls_for_abort)");
   }

--- a/API/src/main/java/org/sikuli/script/runners/JythonRunner.java
+++ b/API/src/main/java/org/sikuli/script/runners/JythonRunner.java
@@ -3,9 +3,7 @@
  */
 package org.sikuli.script.runners;
 
-import org.apache.commons.io.FilenameUtils;
 import org.sikuli.basics.Debug;
-import org.sikuli.script.SikuliException;
 import org.sikuli.script.Sikulix;
 import org.sikuli.script.runnerSupport.JythonSupport;
 import org.sikuli.script.support.IScriptRunner;
@@ -13,7 +11,6 @@ import org.sikuli.script.support.RunTime;
 
 import java.io.File;
 import java.io.PrintStream;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.regex.Matcher;
 
@@ -28,6 +25,7 @@ public class JythonRunner extends AbstractLocalFileScriptRunner {
   public static final String TYPE = "text/jython";
   public static final String[] EXTENSIONS = new String[]{"py"};
 
+  @SuppressWarnings("serial")
   public class AbortedException extends RuntimeException{
 
   }
@@ -43,7 +41,7 @@ public class JythonRunner extends AbstractLocalFileScriptRunner {
    */
   @Override
   public boolean isSupported() {
-    return jythonSupport.isSupported();
+    return JythonSupport.isSupported();
   }
 
   /**

--- a/API/src/main/java/org/sikuli/script/runners/JythonRunner.java
+++ b/API/src/main/java/org/sikuli/script/runners/JythonRunner.java
@@ -32,8 +32,6 @@ public class JythonRunner extends AbstractLocalFileScriptRunner {
 
   private static RunTime runTime = RunTime.get();
 
-  public static boolean aborted = false;
-
   private int lvl = 3;
 
   /**
@@ -104,14 +102,11 @@ public class JythonRunner extends AbstractLocalFileScriptRunner {
   }
 
   private void initAbort() {
-    aborted = false;
-    jythonSupport.interpreterExecString("def trace_calls(frame, evt, arg):\n  if JythonRunner.aborted: \n    raise JythonRunner.AbortedException(None)\n  return trace_calls");
-    jythonSupport.interpreterExecString("sys.settrace(trace_calls)");
-  }
-
-  protected void doAbort() {
-    aborted = true;
-    super.doAbort();
+    jythonSupport.interpreterExecString("def trace_calls_for_abort(frame, evt, arg):\n"
+                                      + "  if JythonRunner.isAborted():\n"
+                                      + "    raise JythonRunner.AbortedException(None)\n"
+                                      + "  return trace_calls_for_abort\n"
+                                      + "sys.settrace(trace_calls_for_abort)");
   }
 
   static JythonSupport jythonSupport = null;

--- a/API/src/main/java/org/sikuli/script/support/IScriptRunner.java
+++ b/API/src/main/java/org/sikuli/script/support/IScriptRunner.java
@@ -296,9 +296,16 @@ public interface IScriptRunner {
   public void abort();
 
   /**
+   * Checks if the currently running script has been aborted.
+   *
+   * @return true if the currently running script has been aborted, false otherwise.
+   */
+  public boolean isAborted();
+
+  /**
    * Checks if abort is supported by this script runner implementation.
    *
-   * @return true is aboort is supported, false otherwise
+   * @return true is abort is supported, false otherwise
    */
   public boolean isAbortSupported();
 


### PR DESCRIPTION
The Thread.stop() call in AbstractScriptRunner.doAbort() is deprecated and seems to cause problems with STDIO. Because the stop() call is only needed for the JythonRunner, this PR removes the stop() call and adds a special doAbort() implementation in JythonRunner.