### PR TITLE
Improve OCR for light text on dark background

### DIFF
--- a/API/src/main/java/org/sikuli/script/TextRecognizer.java
+++ b/API/src/main/java/org/sikuli/script/TextRecognizer.java
@@ -275,6 +275,11 @@ public class TextRecognizer {
     // sharpen the enlarged image again
     img = unsharpMask(img, 5);
 
+    // invert in case of mainly dark background
+    if(Core.mean(img).val[0] < 127) {
+      Core.bitwise_not(img, img);
+    }
+
     // configure tesseract to handle the resized image correctly
     setVariable("user_defined_dpi", "" + optimumDPI);
 


### PR DESCRIPTION
While Tesseract 3 can handle light text on dark background quite well, Tesseract 4 utterly needs dark text on light background (https://github.com/tesseract-ocr/tesseract/wiki/ImproveQuality#inverting-images).

In addition to the enhancements from PR #200 this PR inverts the image if the background is mainly dark.