### PR TITLE
Fixing the repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ the source code of the application or web page you want to act on. [More details
 **API SNAPSHOT on OSSRH**<br>
 
 The repository URL:<br>
-```
+
 <https://oss.sonatype.org/content/repositories/snapshots>
-```
+
 
 The coordinates are:
 ```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ the source code of the application or web page you want to act on. [More details
 
 The repository URL:<br>
 ```
-<url>http://oss.sonatype.org/content/groups/public</url>
+<https://oss.sonatype.org/content/repositories/snapshots>
 ```
 
 The coordinates are:


### PR DESCRIPTION
The current sonatype repo URL didn't work for me, but this updated one did.