### PR TITLE
Move Mouse.init() outside the for loop

### DIFF
--- a/API/src/main/java/org/sikuli/script/Screen.java
+++ b/API/src/main/java/org/sikuli/script/Screen.java
@@ -153,8 +153,10 @@ public class Screen extends Region implements IScreen {
         screens[i] = new Screen(i, nMonitor);
         screens[i].initScreen();
         nMonitor++;
-        Mouse.init();
       }
+
+      Mouse.init();
+
       if (nMonitors > 1) {
         log(lvl, "initScreens: multi monitor mouse check");
         Location lnow = Mouse.at();


### PR DESCRIPTION
Solves issues #120 and #184.

The problem was that Mouse.init() tries to move the mouse to the current screen on each iteration, but the target screen has not been initialized yet. This PR defers Mouse.init() until all screens have been initialized.

Reading the relevant source code, I would consider it safe moving Mouse.init() outside the for loop.
