### PR TITLE
Handle the occasionally occurring ClassNotFoundException during cleanUp

### DIFF
--- a/API/src/main/java/org/sikuli/script/support/RunTime.java
+++ b/API/src/main/java/org/sikuli/script/support/RunTime.java
@@ -1272,8 +1272,14 @@ public class RunTime {
       Settings.setShowActions(false);
       FindFailed.reset();
     }
-    VNCScreen.stopAll();
-    ExtensionManager.invokeStatic("ADBScreen.stop");
+
+    try {
+      VNCScreen.stopAll();
+      ExtensionManager.invokeStatic("ADBScreen.stop");
+    } catch (Exception e) {
+      Debug.info("Error while stopping VNCScreen: %s", e.getMessage());
+    }
+
     Observing.cleanUp();
     HotkeyManager.reset(isTerminating);
     if (null != cleanupRobot) {


### PR DESCRIPTION
We occasionally get a ClassNotFoundException on Windows concerning the VNCScreen class. After this we have to teminate SikuliX using the Task Manager.

Don't know exactly why the Exception occurs and can't reproduce it reliably, so I would consider a simple try/catch a good enough fix here.