### PR TITLE
Add some delay after setting IDE to invisible to give it some time to vanish

### DIFF
--- a/IDE/src/main/java/org/sikuli/ide/ButtonCapture.java
+++ b/IDE/src/main/java/org/sikuli/ide/ButtonCapture.java
@@ -86,10 +86,17 @@ class ButtonCapture extends ButtonOnToolbar implements ActionListener, Cloneable
   IScreen defaultScreen = null;
   ScreenImage sImgNonLocal = null;
 
-  public void capture(final int delay) {
+  public void capture(int delay) {
     String line = "";
     SikulixIDE ide = SikulixIDE.get();
-    ide.setVisible(false);
+    if (ide.isVisible()) {
+      // Set minimum delay if IDE is visible to give
+      // the IDE some time to vanish before taking the
+      // screenshot. IDE might already be hidden in
+      // in case of capture hot key.
+      delay = Math.max(delay, 500);
+      ide.setVisible(false);
+    }
     EditorPane codePane = ide.getCurrentCodePane();
     line = codePane.getLineTextAtCaret();
     givenName = codePane.parseLineText("#" + line.trim());

--- a/IDE/src/main/java/org/sikuli/ide/EditorRegionButton.java
+++ b/IDE/src/main/java/org/sikuli/ide/EditorRegionButton.java
@@ -9,6 +9,7 @@ import java.awt.image.*;
 import javax.swing.*;
 import org.sikuli.util.OverlayCapturePrompt;
 import org.sikuli.script.support.IScreen;
+import org.sikuli.script.support.RunTime;
 import org.sikuli.script.Region;
 import org.sikuli.script.ScreenImage;
 import org.sikuli.basics.Debug;
@@ -38,6 +39,7 @@ class EditorRegionButton extends JButton implements ActionListener, EventObserve
   public void actionPerformed(ActionEvent ae) {
     SikulixIDE ide = SikulixIDE.get();
     ide.setVisible(false);
+    RunTime.pause(0.5f);
     Screen.doPrompt(SikulixIDE._I("msgCapturePrompt"), this);
   }
 


### PR DESCRIPTION
The IDE might appear on the captured screenshot otherwise.

In some places, the delay is already present. Added it in the other places as well.