### PR TITLE
Fix line displacement after resizing image

### DIFF
--- a/IDE/src/main/java/org/sikuli/ide/PatternWindow.java
+++ b/IDE/src/main/java/org/sikuli/ide/PatternWindow.java
@@ -313,6 +313,7 @@ public class PatternWindow extends JFrame {
       _imgBtn.reloadImage();
       _screenshot.reloadImage();
       paneNaming.reloadImage();
+      currentPane.doReparse();
 
       File screenshotImageFile = FileManager.getScreenshotImageFile(file.getName(), SikulixIDE.get().getCurrentCodePane().getImagePath());
       if(!screenshotImageFile.exists()) {


### PR DESCRIPTION
After resizing an image in the pattern window the lines are displaced. This is a minor annoyance because the displacement gets fixed automatically upon the next reparse/repaint (e.g. by simply clicking into the editor area). But because it just looks bad, this PR adds an additional doReparse() when the image has been resized.