### PR TITLE
Fix steal focus and show on taskbar

### DIFF
--- a/API/src/main/java/org/sikuli/util/Highlight.java
+++ b/API/src/main/java/org/sikuli/util/Highlight.java
@@ -60,6 +60,9 @@ public class Highlight extends JFrame {
       setBackground(new Color(0, 0, 0, 0));
       setAlwaysOnTop(true);
       setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+      setType(JFrame.Type.UTILITY);
+      setFocusableWindowState(false);
+      setAutoRequestFocus(false);
     }
   }
 


### PR DESCRIPTION
Whenever the highlightOn() is used, prevent SikuliX from stealing the app focus.
Also, prevent the JFrame from showing on the taskbar