### PR TITLE
Do not reparse editor pane on pattern image resize

### DIFF
--- a/IDE/src/main/java/org/sikuli/ide/PatternPaneTargetOffset.java
+++ b/IDE/src/main/java/org/sikuli/ide/PatternPaneTargetOffset.java
@@ -173,7 +173,7 @@ class PatternPaneTargetOffset extends JPanel implements
 
 	@Override
 	public void mouseReleased(MouseEvent me) {
-	  if (resizableRect.isVisible()) {
+	  if (me.getComponent() == resizableRect) {
 	    Rectangle oldBounds;
 
 	    if (changedBounds != null) {

--- a/IDE/src/main/java/org/sikuli/ide/PatternWindow.java
+++ b/IDE/src/main/java/org/sikuli/ide/PatternWindow.java
@@ -306,14 +306,13 @@ public class PatternWindow extends JFrame {
 		  try {
         ImageIO.write(changedImg, "png", file);
       } catch (IOException e) {
-        // TODO Auto-generated catch block
-        e.printStackTrace();
+        Debug.error("PatternWindow: Error while saving resized pattern image: %s", e.getMessage());
       }
 
       _imgBtn.reloadImage();
       _screenshot.reloadImage();
       paneNaming.reloadImage();
-      currentPane.doReparse();
+      currentPane.repaint();
 
       File screenshotImageFile = FileManager.getScreenshotImageFile(file.getName(), SikulixIDE.get().getCurrentCodePane().getImagePath());
       if(!screenshotImageFile.exists()) {

--- a/IDE/src/main/java/org/sikuli/idesupport/Resizable.java
+++ b/IDE/src/main/java/org/sikuli/idesupport/Resizable.java
@@ -318,9 +318,9 @@ public class Resizable extends JComponent {
         public void mouseReleased(MouseEvent me) {
           Rectangle bounds = Resizable.this.getBounds();
           if(moved) {
-            getParent().dispatchEvent(new MouseEvent(getParent(), MouseEvent.MOUSE_RELEASED, me.getWhen(), me.getModifiers(), bounds.x + me.getX(), bounds.y + me.getY(), me.getClickCount(), false));
+            getParent().dispatchEvent(new MouseEvent(Resizable.this, MouseEvent.MOUSE_RELEASED, me.getWhen(), me.getModifiers(), bounds.x + me.getX(), bounds.y + me.getY(), me.getClickCount(), false));
           } else {
-            getParent().dispatchEvent(new MouseEvent(getParent(), MouseEvent.MOUSE_PRESSED, me.getWhen(), me.getModifiers(), bounds.x + me.getX(), bounds.y + me.getY(), me.getClickCount(), false));
+            getParent().dispatchEvent(new MouseEvent(Resizable.this, MouseEvent.MOUSE_PRESSED, me.getWhen(), me.getModifiers(), bounds.x + me.getX(), bounds.y + me.getY(), me.getClickCount(), false));
           }
           moved = false;
           startPos = null;


### PR DESCRIPTION
Fixes regression added with PR #247.

When the bounds and the click point changes at the same time, the click point change gets lost due to the `doReparse()` call. A repaint() is sufficient as well to mitigate the issue solved in PR #247.

It also fixes a case when the click point is set outside the resize box. Previously this was also interpreted as a resize and triggered the said `doReparse()`.