### PR TITLE
Fix Pattern code generation when adding pattern using the capture button

### DIFF
--- a/IDE/src/main/java/org/sikuli/ide/EditorPane.java
+++ b/IDE/src/main/java/org/sikuli/ide/EditorPane.java
@@ -1069,7 +1069,17 @@ public class EditorPane extends JTextPane {
     org.sikuli.script.Pattern pattern = new org.sikuli.script.Pattern();
     pattern.setFilename(ifn);
     pattern.setImage(img);
-    pattern.similar(sim);
+    /*
+     * We have to do something nasty here because in pattern
+     * the similarity is a double and here we get the similarity
+     * as a float. This means that e.g. 0.7f will be converted to
+     * 0.699999988079071d. Usually this doesn't hurt, but it
+     * causes the code generator to produce code like
+     * Pattern("foo.png").similar(0.70)) instead of just "foo.png"
+     * (0.7 != 0.699999988079071). The toString and parseDouble
+     * converts the float into the proper double value.
+     */
+    pattern.similar(Double.parseDouble(Float.toString(sim)));
     pattern.targetOffset(off);
     pattern.resize(resizeFactor);
 


### PR DESCRIPTION
Problem was that the Pattern takes the similarity as double and in the EditorPane we get the similarity as float. 0.7f is 0.699999988079071d which is obviously not the same. This caused the code generator to produce the longer version.

Doing this somewhat strange conversion gives the proper double value.

To better illustrate the problem:
```
float f = 0.7f;
double d = (double) f; // 0.699999988079071d
String.format(Locale.ENGLISH, "%.2f", d); // "0.70"
d == f; // false
String s = Float.toString(f); // "0.7"
d = Double.parseDouble(s); // 0.7d
d == f; // true
```
I hate computers :-)