### PR TITLE
Implements recording of mouse wheel

### DIFF
--- a/API/src/main/java/org/sikuli/script/Key.java
+++ b/API/src/main/java/org/sikuli/script/Key.java
@@ -603,6 +603,7 @@ public class Key {
       case Key.C_CTRL:  return "#CTRL.";
       case Key.C_ALT:   return "#ALT.";
       case Key.C_META:  return "#META.";
+      case Key.C_ALTGR: return "#ALTGR.";
 
       default:
         return "" + key;

--- a/API/src/main/java/org/sikuli/script/Mouse.java
+++ b/API/src/main/java/org/sikuli/script/Mouse.java
@@ -480,19 +480,26 @@ public class Mouse {
    * @param steps value
    */
   public static void wheel(int direction, int steps) {
-    wheel(direction, steps, null);
+    wheel(null, direction, steps, 0);
   }
 
-  protected static void wheel(int direction, int steps, Region region) {
-    wheel(direction,steps,region, WHEEL_STEP_DELAY);
+  protected static void wheel(Region region, int direction, int steps, int modifiers) {
+    wheel(region, direction,steps, modifiers, WHEEL_STEP_DELAY);
   }
 
-  protected static void wheel(int direction, int steps, Region region, int stepDelay) {
+  protected static void wheel(Region region, int direction, int steps, int modifiers, int stepDelay) {
+    System.out.println(stepDelay);
+
     if (get().device.isSuspended()) {
       return;
     }
     IRobot r = Screen.getRobot(region);
     get().device.use(region);
+
+    if (modifiers > 0) {
+      r.pressModifiers(modifiers);
+    }
+
     String wheelComment = (direction == WHEEL_UP ? "Content upwards" : "Content downwards");
     if (!Settings.WheelNatural) {
       wheelComment = (direction == WHEEL_UP ? "Content downwards" : "Content upwards");
@@ -503,6 +510,11 @@ public class Mouse {
       r.mouseWheel(direction);
       r.delay(stepDelay);
     }
+
+    if (modifiers > 0) {
+      r.releaseModifiers(modifiers);
+    }
+
     get().device.let(region);
   }
 }

--- a/API/src/main/java/org/sikuli/script/Region.java
+++ b/API/src/main/java/org/sikuli/script/Region.java
@@ -21,6 +21,18 @@ import java.util.*;
  */
 public class Region {
 
+  /*
+   * Used for LEGACY handling in
+   * int wheel(PFRML target, int direction, int steps, int modifiers)
+   */
+  private final Set<Integer> WHEEL_MODIFIERS = new HashSet<>(Arrays.asList(new Integer[] {
+    0,
+    KeyModifier.CTRL,
+    KeyModifier.ALT,
+    KeyModifier.SHIFT,
+    KeyModifier.CMD
+  }));
+
   private static String me = "Region: ";
   private static int lvl = 3;
 
@@ -3935,8 +3947,44 @@ public class Region {
    * @return 1 if possible, 0 otherwise
    */
   public int click() {
+    return click(0);
+  }
+
+  /**
+   * left click at the region's last successful match <br>use center if no lastMatch <br>if region is a match: click
+   * targetOffset
+   *
+   * @param modifiers constants according to class Key - combine using +
+   * @return 1 if possible, 0 otherwise
+   */
+  public int click(String modifiers) {
+    int modifiersMask = Key.convertModifiers(modifiers);
+
+    /*
+     * modifiers might be a pattern file name
+     * eg. Region(...).click("pattern.png")
+     */
+    if(modifiersMask == 0) {
+      try { // needed to cut throw chain for FindFailed
+        return click(modifiers, 0);
+      } catch (FindFailed ex) {
+        return 0;
+      }
+    }
+
+    return click(modifiersMask);
+  }
+
+  /**
+   * left click at the region's last successful match <br>use center if no lastMatch <br>if region is a match: click
+   * targetOffset
+   *
+   * @param modifiers the value of the resulting bitmask (see KeyModifier)   *
+   * @return 1 if possible, 0 otherwise
+   */
+  public int click(int modifiers) {
     try { // needed to cut throw chain for FindFailed
-      return click(checkMatch(), 0);
+      return click(checkMatch(), modifiers);
     } catch (FindFailed ex) {
       return 0;
     }
@@ -3963,11 +4011,27 @@ public class Region {
    *
    * @param <PFRML>   to search: Pattern, Filename, Text, Region, Match or Location
    * @param target    Pattern, Filename, Text, Region, Match or Location
+   * @param modifiers constants according to class Key - combine using +
+   * @return 1 if possible, 0 otherwise
+   * @throws FindFailed for Pattern or Filename
+   */
+  public <PFRML> int click(PFRML target, String modifiers) throws FindFailed {
+    int modifiersMask = Key.convertModifiers(modifiers);
+    return click(target, modifiersMask);
+  }
+
+  /**
+   * left click at the given target location<br> holding down the given modifier keys<br>
+   * Pattern or Filename - do a find before and use the match<br> Region - position at center<br>
+   * Match - position at match's targetOffset<br> Location - position at that point<br>
+   *
+   * @param <PFRML>   to search: Pattern, Filename, Text, Region, Match or Location
+   * @param target    Pattern, Filename, Text, Region, Match or Location
    * @param modifiers the value of the resulting bitmask (see KeyModifier)
    * @return 1 if possible, 0 otherwise
    * @throws FindFailed for Pattern or Filename
    */
-  public <PFRML> int click(PFRML target, Integer modifiers) throws FindFailed {
+  public <PFRML> int click(PFRML target, int modifiers) throws FindFailed {
     int ret = 0;
     if (target instanceof ArrayList) {
       ArrayList parms = (ArrayList) target;
@@ -3992,8 +4056,44 @@ public class Region {
    * @return 1 if possible, 0 otherwise
    */
   public int doubleClick() {
+    return doubleClick(0);
+  }
+
+  /**
+   * double click at the region's last successful match <br>use center if no lastMatch <br>if region is a match: click
+   * targetOffset
+   *
+   * @param modifiers constants according to class Key - combine using +
+   * @return 1 if possible, 0 otherwise
+   */
+  public int doubleClick(String modifiers) {
+    int modifiersMask = Key.convertModifiers(modifiers);
+
+    /*
+     * modifiers might be a pattern file name
+     * eg. Region(...).click("pattern.png")
+     */
+    if(modifiersMask == 0) {
+      try { // needed to cut throw chain for FindFailed
+        return doubleClick(modifiers, 0);
+      } catch (FindFailed ex) {
+        return 0;
+      }
+    }
+
+    return doubleClick(modifiersMask);
+  }
+
+  /**
+   * double click at the region's last successful match <br>use center if no lastMatch <br>if region is a match: click
+   * targetOffset
+   *
+   * @param modifiers the value of the resulting bitmask (see KeyModifier)
+   * @return 1 if possible, 0 otherwise
+   */
+  public int doubleClick(int modifiers) {
     try { // needed to cut throw chain for FindFailed
-      return doubleClick(checkMatch(), 0);
+      return doubleClick(checkMatch(), modifiers);
     } catch (FindFailed ex) {
       return 0;
     }
@@ -4020,11 +4120,27 @@ public class Region {
    *
    * @param <PFRML>   Pattern, Filename, Text, Region, Match or Location
    * @param target    Pattern, Filename, Text, Region, Match or Location
+   * @param modifiers constants according to class Key - combine using +
+   * @return 1 if possible, 0 otherwise
+   * @throws FindFailed for Pattern or Filename
+   */
+  public <PFRML> int doubleClick(PFRML target, String modifiers) throws FindFailed {
+    int modifiersMask = Key.convertModifiers(modifiers);
+    return doubleClick(target, modifiersMask);
+  }
+
+  /**
+   * double click at the given target location<br> holding down the given modifier keys<br>
+   * Pattern or Filename - do a find before and use the match<br> Region - position at center<br > Match - position at
+   * match's targetOffset<br> Location - position at that point<br>
+   *
+   * @param <PFRML>   Pattern, Filename, Text, Region, Match or Location
+   * @param target    Pattern, Filename, Text, Region, Match or Location
    * @param modifiers the value of the resulting bitmask (see KeyModifier)
    * @return 1 if possible, 0 otherwise
    * @throws FindFailed for Pattern or Filename
    */
-  public <PFRML> int doubleClick(PFRML target, Integer modifiers) throws FindFailed {
+  public <PFRML> int doubleClick(PFRML target, int modifiers) throws FindFailed {
     Location loc = getLocationFromTarget(target);
     int ret = 0;
     if (null != loc) {
@@ -4041,8 +4157,44 @@ public class Region {
    * @return 1 if possible, 0 otherwise
    */
   public int rightClick() {
+    return rightClick(0);
+  }
+
+  /**
+   * right click at the region's last successful match <br>use center if no lastMatch <br>if region is a match: click
+   * targetOffset
+   *
+   * @param modifiers constants according to class Key - combine using +
+   * @return 1 if possible, 0 otherwise
+   */
+  public int rightClick(String modifiers) {
+    int modifiersMask = Key.convertModifiers(modifiers);
+
+    /*
+     * modifiers might be a pattern file name
+     * eg. Region(...).click("pattern.png")
+     */
+    if(modifiersMask == 0) {
+      try { // needed to cut throw chain for FindFailed
+        return rightClick(modifiers, 0);
+      } catch (FindFailed ex) {
+        return 0;
+      }
+    }
+
+    return rightClick(modifiersMask);
+  }
+
+  /**
+   * right click at the region's last successful match <br>use center if no lastMatch <br>if region is a match: click
+   * targetOffset
+   *
+   * @param modifiers the value of the resulting bitmask (see KeyModifier)
+   * @return 1 if possible, 0 otherwise
+   */
+  public int rightClick(int modifiers) {
     try { // needed to cut throw chain for FindFailed
-      return rightClick(checkMatch(), 0);
+      return rightClick(checkMatch(), modifiers);
     } catch (FindFailed ex) {
       return 0;
     }
@@ -4068,11 +4220,27 @@ public class Region {
    *
    * @param <PFRML>   Pattern, Filename, Text, Region, Match or Location
    * @param target    Pattern, Filename, Text, Region, Match or Location
+   * @param modifiers constants according to class Key - combine using +
+   * @return 1 if possible, 0 otherwise
+   * @throws FindFailed for Pattern or Filename
+   */
+  public <PFRML> int rightClick(PFRML target, String modifiers) throws FindFailed {
+    int modifiersMask = Key.convertModifiers(modifiers);
+    return rightClick(target, modifiersMask);
+  }
+
+  /**
+   * right click at the given target location<br> holding down the given modifier keys<br>
+   * Pattern or Filename - do a find before and use the match<br> Region - position at center<br > Match - position at
+   * match's targetOffset<br> Location - position at that point<br>
+   *
+   * @param <PFRML>   Pattern, Filename, Text, Region, Match or Location
+   * @param target    Pattern, Filename, Text, Region, Match or Location
    * @param modifiers the value of the resulting bitmask (see KeyModifier)
    * @return 1 if possible, 0 otherwise
    * @throws FindFailed for Pattern or Filename
    */
-  public <PFRML> int rightClick(PFRML target, Integer modifiers) throws FindFailed {
+  public <PFRML> int rightClick(PFRML target, int modifiers) throws FindFailed {
     Location loc = getLocationFromTarget(target);
     int ret = 0;
     if (null != loc) {
@@ -4301,8 +4469,69 @@ public class Region {
    * @return 1 in any case
    */
   public int wheel(int direction, int steps) {
-    Mouse.wheel(direction, steps, this);
-    return 1;
+   return wheel(direction, steps, 0);
+  }
+
+  /**
+   * Move the wheel at the current mouse position<br> the given steps in the given direction: <br >Button.WHEEL_DOWN,
+   * Button.WHEEL_UP
+   *
+   * @param direction to move the wheel
+   * @param steps     the number of steps
+   * @param modifiers constants according to class Key - combine using +
+   * @return 1 in any case
+   */
+  public int wheel(int direction, int steps, String modifiers) {
+    int modifiersMask = Key.convertModifiers(modifiers);
+    return wheel(direction, steps, modifiersMask);
+  }
+
+
+  /**
+   * Move the wheel at the current mouse position<br> the given steps in the given direction: <br >Button.WHEEL_DOWN,
+   * Button.WHEEL_UP
+   *
+   * @param direction to move the wheel
+   * @param steps     the number of steps
+   * @param modifiers the value of the resulting bitmask (see KeyModifier)
+   * @return 1 in any case
+   */
+  public int wheel(int direction, int steps, int modifiers) {
+    return wheel(direction, steps, modifiers, Mouse.WHEEL_STEP_DELAY);
+  }
+
+  /**
+   * Move the wheel at the current mouse position<br> the given steps in the given direction: <br >Button.WHEEL_DOWN,
+   * Button.WHEEL_UP
+   *
+   * @param direction to move the wheel
+   * @param steps     the number of steps
+   * @param modifiers constants according to class Key - combine using +
+   * @param stepDelay number of milliseconds to wait when incrementing the step value
+   * @return 1 in any case
+   */
+  public int wheel(int direction, int steps, String modifiers, int stepDelay) {
+    int modifiersMask = Key.convertModifiers(modifiers);
+    return wheel(direction, steps, modifiersMask, stepDelay);
+  }
+
+  /**
+   * Move the wheel at the current mouse position<br> the given steps in the given direction: <br >Button.WHEEL_DOWN,
+   * Button.WHEEL_UP
+   *
+   * @param direction to move the wheel
+   * @param steps     the number of steps
+   * @param modifiers the value of the resulting bitmask (see KeyModifier)
+   * @param stepDelay number of milliseconds to wait when incrementing the step value
+   * @return 1 in any case
+   */
+  public int wheel(int direction, int steps, int modifiers, int stepDelay) {
+    try { // needed to cut throw chain for FindFailed
+      wheel(checkMatch(),  direction, steps, modifiers, stepDelay);
+      return 1;
+    } catch (FindFailed ex) {
+      return 0;
+    }
   }
 
   /**
@@ -4317,7 +4546,7 @@ public class Region {
    * @throws FindFailed if the Find operation failed
    */
   public <PFRML> int wheel(PFRML target, int direction, int steps) throws FindFailed {
-    return wheel(target, direction, steps, Mouse.WHEEL_STEP_DELAY);
+    return wheel(target, direction, steps, 0);
   }
 
   /**
@@ -4328,17 +4557,84 @@ public class Region {
    * @param target    Pattern, Filename, Text, Region, Match or Location
    * @param direction to move the wheel
    * @param steps     the number of steps
-   * @param stepDelay number of miliseconds to wait when incrementing the step value
+   * @param modifiers constants according to class Key - combine using +
    * @return 1 if possible, 0 otherwise
    * @throws FindFailed if the Find operation failed
    */
-  public <PFRML> int wheel(PFRML target, int direction, int steps, int stepDelay) throws FindFailed {
+  public <PFRML> int wheel(PFRML target, int direction, int steps, String modifiers) throws FindFailed {
+    int modifiersMask = Key.convertModifiers(modifiers);
+    return wheel(target, direction, steps, modifiersMask, Mouse.WHEEL_STEP_DELAY);
+  }
+
+  /**
+   * move the mouse pointer to the given target location<br> and move the wheel the given steps in the given direction:
+   * <br>Button.WHEEL_DOWN, Button.WHEEL_UP
+   *
+   * @param <PFRML>   Pattern, Filename, Text, Region, Match or Location target
+   * @param target    Pattern, Filename, Text, Region, Match or Location
+   * @param direction to move the wheel
+   * @param steps     the number of steps
+   * @param modifiers the value of the resulting bitmask (see KeyModifier)
+   * @return 1 if possible, 0 otherwise
+   * @throws FindFailed if the Find operation failed
+   */
+  public <PFRML> int wheel(PFRML target, int direction, int steps, int modifiers) throws FindFailed {
+    int stepDelay = Mouse.WHEEL_STEP_DELAY;
+
+    /*
+     * LEGACY
+     * Previous method signature was
+     *
+     * public <PFRML> int wheel(PFRML target, int direction, int steps, int stepDelay)
+     *
+     * That's why we interpret the modifiers parameter as stepDelay if it is not a
+     * reasonable modifier for wheel actions.
+     */
+    if (!WHEEL_MODIFIERS.contains(modifiers)) {
+      modifiers = 0;
+      stepDelay = modifiers;
+    }
+
+    return wheel(target, direction, steps, modifiers, stepDelay);
+  }
+
+  /**
+   * move the mouse pointer to the given target location<br> and move the wheel the given steps in the given direction:
+   * <br>Button.WHEEL_DOWN, Button.WHEEL_UP
+   *
+   * @param <PFRML>   Pattern, Filename, Text, Region, Match or Location target
+   * @param target    Pattern, Filename, Text, Region, Match or Location
+   * @param direction to move the wheel
+   * @param steps     the number of steps
+   * @param modifiers constants according to class Key - combine using +
+   * @param stepDelay number of milliseconds to wait when incrementing the step value
+   * @return 1 if possible, 0 otherwise
+   * @throws FindFailed if the Find operation failed
+   */
+  public <PFRML> int wheel(PFRML target, int direction, int steps, String modifiers, int stepDelay) throws FindFailed {
+    int modifiersMask = Key.convertModifiers(modifiers);
+    return wheel(target, direction, steps, modifiersMask, stepDelay);
+  }
+
+  /**
+   * move the mouse pointer to the given target location<br> and move the wheel the given steps in the given direction:
+   * <br>Button.WHEEL_DOWN, Button.WHEEL_UP
+   *
+   * @param <PFRML>   Pattern, Filename, Text, Region, Match or Location target
+   * @param target    Pattern, Filename, Text, Region, Match or Location
+   * @param direction to move the wheel
+   * @param steps     the number of steps
+   * @param stepDelay number of milliseconds to wait when incrementing the step value
+   * @return 1 if possible, 0 otherwise
+   * @throws FindFailed if the Find operation failed
+   */
+  public <PFRML> int wheel(PFRML target, int direction, int steps, int modifiers, int stepDelay) throws FindFailed {
     Location loc = getLocationFromTarget(target);
     if (loc != null) {
       Mouse.use(this);
       Mouse.keep(this);
       Mouse.move(loc, this);
-      Mouse.wheel(direction, steps, this, stepDelay);
+      Mouse.wheel(this, direction, steps, modifiers, stepDelay);
       Mouse.let(this);
       return 1;
     }
@@ -4590,13 +4886,20 @@ public class Region {
    */
   public int type(String text, String modifiers) {
     String target = null;
-    int modifiersNew = Key.convertModifiers(modifiers);
-    if (modifiersNew == 0) {
+    int modifiersMask = Key.convertModifiers(modifiers);
+
+    /*
+     * If no modifiers are active it might be that the
+     * method has been called with the intention to call
+     * in fact type(String patternFilename, String text).
+     * e.g. Region(...).type("pattern.png", "Hello world")
+     */
+    if (modifiersMask == 0) {
       target = text;
       text = modifiers;
     }
     try {
-      return keyin(target, text, modifiersNew);
+      return keyin(target, text, modifiersMask);
     } catch (FindFailed findFailed) {
       return 0;
     }
@@ -4646,8 +4949,8 @@ public class Region {
    * @throws FindFailed if not found
    */
   public <PFRML> int type(PFRML target, String text, String modifiers) throws FindFailed {
-    int modifiersNew = Key.convertModifiers(modifiers);
-    return keyin(target, text, modifiersNew);
+    int modifiersMask = Key.convertModifiers(modifiers);
+    return keyin(target, text, modifiersMask);
   }
 
   private <PFRML> int keyin(PFRML target, String text, int modifiers) throws FindFailed {

--- a/API/src/main/java/org/sikuli/script/support/Recorder.java
+++ b/API/src/main/java/org/sikuli/script/support/Recorder.java
@@ -26,6 +26,8 @@ import org.jnativehook.keyboard.NativeKeyListener;
 import org.jnativehook.mouse.NativeMouseEvent;
 import org.jnativehook.mouse.NativeMouseListener;
 import org.jnativehook.mouse.NativeMouseMotionListener;
+import org.jnativehook.mouse.NativeMouseWheelEvent;
+import org.jnativehook.mouse.NativeMouseWheelListener;
 import org.sikuli.basics.Debug;
 import org.sikuli.basics.Settings;
 import org.sikuli.script.Finder;
@@ -39,7 +41,7 @@ import org.sikuli.script.support.recorder.actions.IRecordedAction;
  *
  * @author balmma
  */
-public class Recorder implements NativeKeyListener, NativeMouseListener, NativeMouseMotionListener {
+public class Recorder implements NativeKeyListener, NativeMouseListener, NativeMouseMotionListener, NativeMouseWheelListener {
 
   private static final long MOUSE_SCREENSHOT_DELAY = 500;
   private static final long MOUSE_MOVE_SCREENSHOT_DELAY = 100;
@@ -175,6 +177,7 @@ public class Recorder implements NativeKeyListener, NativeMouseListener, NativeM
       GlobalScreen.addNativeKeyListener(this);
       GlobalScreen.addNativeMouseListener(this);
       GlobalScreen.addNativeMouseMotionListener(this);
+      GlobalScreen.addNativeMouseWheelListener(this);
     }
   }
 
@@ -188,6 +191,7 @@ public class Recorder implements NativeKeyListener, NativeMouseListener, NativeM
     if (running) {
       running = false;
 
+      GlobalScreen.removeNativeMouseWheelListener(this);
       GlobalScreen.removeNativeMouseMotionListener(this);
       GlobalScreen.removeNativeMouseListener(this);
       GlobalScreen.removeNativeKeyListener(this);
@@ -251,5 +255,11 @@ public class Recorder implements NativeKeyListener, NativeMouseListener, NativeM
       saveMousePosition(e);
       add(e, MOUSE_MOVE_SCREENSHOT_DELAY);
     }
+  }
+
+  @Override
+  public void nativeMouseWheelMoved(NativeMouseWheelEvent e) {
+    saveMousePosition(e);
+    add(e, MOUSE_SCREENSHOT_DELAY);
   }
 }

--- a/API/src/main/java/org/sikuli/script/support/generators/ICodeGenerator.java
+++ b/API/src/main/java/org/sikuli/script/support/generators/ICodeGenerator.java
@@ -37,6 +37,8 @@ public interface ICodeGenerator {
 
   public String rightClick(Pattern pattern, String[] modifiers);
 
+  public String wheel(Pattern pattern, int direction, int steps, String[] modifiers, long stepDelay);
+
   public String typeText(String text, String[] modifiers);
 
   public String typeKey(String key, String[] modifiers);

--- a/API/src/main/java/org/sikuli/script/support/generators/JythonCodeGenerator.java
+++ b/API/src/main/java/org/sikuli/script/support/generators/JythonCodeGenerator.java
@@ -9,6 +9,7 @@ import java.util.Locale;
 
 import org.sikuli.script.Image;
 import org.sikuli.script.Location;
+import org.sikuli.script.Mouse;
 import org.sikuli.script.Pattern;
 import org.sikuli.script.support.recorder.actions.IRecordedAction;
 
@@ -70,6 +71,37 @@ public class JythonCodeGenerator implements ICodeGenerator {
   @Override
   public String rightClick(Pattern pattern, String[] modifiers) {
     return mouse("rightClick", pattern, modifiers);
+  }
+
+  @Override
+  public String wheel(Pattern pattern, int direction, int steps, String[] modifiers, long stepDelay) {
+    String code = "wheel(";
+
+    if (pattern != null) {
+      code += pattern(pattern, null);
+      code += ", ";
+    }
+
+    code += direction > 0 ? "WHEEL_DOWN" : "WHEEL_UP";
+    code += ", ";
+    code += steps;
+
+    if(modifiers.length > 0) {
+      code += ", ";
+      code += String.join(" + ", modifiers);
+    }
+
+    if (stepDelay != Mouse.WHEEL_STEP_DELAY) {
+      if(modifiers.length == 0) {
+        code += ", 0";
+      }
+
+      code += ", ";
+      code += stepDelay;
+    }
+
+    code += ")";
+    return code;
   }
 
   @Override

--- a/API/src/main/java/org/sikuli/script/support/recorder/actions/ClickAction.java
+++ b/API/src/main/java/org/sikuli/script/support/recorder/actions/ClickAction.java
@@ -7,26 +7,17 @@ package org.sikuli.script.support.recorder.actions;
 import org.sikuli.script.Pattern;
 import org.sikuli.script.support.generators.ICodeGenerator;
 
-public class ClickAction implements IRecordedAction {
-  private Pattern pattern;
+public class ClickAction extends PatternAction implements IRecordedAction {
   private String[] modifiers;
 
   public ClickAction(Pattern pattern, String[] modifiers) {
-    this.pattern = pattern;
+    super(pattern);
     this.modifiers = modifiers;
   }
 
   @Override
   public String generate(ICodeGenerator generator) {
-    return generator.click(pattern, modifiers);
-  }
-
-  public Pattern getPattern() {
-    return pattern;
-  }
-
-  public void setPattern(Pattern pattern) {
-    this.pattern = pattern;
+    return generator.click(getPattern(), modifiers);
   }
 
   public String[] getModifiers() {

--- a/API/src/main/java/org/sikuli/script/support/recorder/actions/MouseDownAction.java
+++ b/API/src/main/java/org/sikuli/script/support/recorder/actions/MouseDownAction.java
@@ -7,17 +7,16 @@ package org.sikuli.script.support.recorder.actions;
 import org.sikuli.script.Pattern;
 import org.sikuli.script.support.generators.ICodeGenerator;
 
-public class MouseDownAction implements IRecordedAction {
-  private Pattern pattern;
+public class MouseDownAction extends PatternAction implements IRecordedAction {
   private String[] buttons;
 
   public MouseDownAction(Pattern pattern, String[] buttons) {
-    this.pattern = pattern;
+    super(pattern);
     this.buttons = buttons;
   }
 
   @Override
   public String generate(ICodeGenerator generator) {
-    return generator.mouseDown(pattern, buttons);
+    return generator.mouseDown(getPattern(), buttons);
   }
 }

--- a/API/src/main/java/org/sikuli/script/support/recorder/actions/MouseMoveAction.java
+++ b/API/src/main/java/org/sikuli/script/support/recorder/actions/MouseMoveAction.java
@@ -7,15 +7,13 @@ package org.sikuli.script.support.recorder.actions;
 import org.sikuli.script.Pattern;
 import org.sikuli.script.support.generators.ICodeGenerator;
 
-public class MouseMoveAction implements IRecordedAction {
-  private Pattern pattern;
-
+public class MouseMoveAction extends PatternAction implements IRecordedAction {
   public MouseMoveAction(Pattern pattern) {
-    this.pattern = pattern;
+    super(pattern);
   }
 
   @Override
   public String generate(ICodeGenerator generator) {
-    return generator.mouseMove(pattern);
+    return generator.mouseMove(getPattern());
   }
 }

--- a/API/src/main/java/org/sikuli/script/support/recorder/actions/MouseUpAction.java
+++ b/API/src/main/java/org/sikuli/script/support/recorder/actions/MouseUpAction.java
@@ -7,17 +7,16 @@ package org.sikuli.script.support.recorder.actions;
 import org.sikuli.script.Pattern;
 import org.sikuli.script.support.generators.ICodeGenerator;
 
-public class MouseUpAction implements IRecordedAction {
-  private Pattern pattern;
+public class MouseUpAction extends PatternAction implements IRecordedAction {
   private String[] buttons;
 
   public MouseUpAction(Pattern pattern, String[] buttons) {
-    this.pattern = pattern;
+    super(pattern);
     this.buttons = buttons;
   }
 
   @Override
   public String generate(ICodeGenerator generator) {
-    return generator.mouseUp(pattern, buttons);
+    return generator.mouseUp(getPattern(), buttons);
   }
 }

--- a/API/src/main/java/org/sikuli/script/support/recorder/actions/MouseWheelAction.java
+++ b/API/src/main/java/org/sikuli/script/support/recorder/actions/MouseWheelAction.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2010-2018, sikuli.org, sikulix.com - MIT license
+ */
+
+package org.sikuli.script.support.recorder.actions;
+
+import org.sikuli.script.Pattern;
+import org.sikuli.script.support.generators.ICodeGenerator;
+
+public class MouseWheelAction extends PatternAction implements IRecordedAction {
+  private int direction;
+  private int steps;
+  private String[] modifiers;
+  private long stepDelay;
+
+  public MouseWheelAction(Pattern pattern, int direction, int steps, String[] modifiers, long stepDelay) {
+    super(pattern);
+    this.direction = direction;
+    this.steps = steps;
+    this.modifiers = modifiers;
+    this.stepDelay = stepDelay;
+  }
+
+  @Override
+  public String generate(ICodeGenerator generator) {
+    return generator.wheel(getPattern(), direction, steps, modifiers, stepDelay);
+  }
+}

--- a/API/src/main/java/org/sikuli/script/support/recorder/actions/PatternAction.java
+++ b/API/src/main/java/org/sikuli/script/support/recorder/actions/PatternAction.java
@@ -1,0 +1,20 @@
+package org.sikuli.script.support.recorder.actions;
+
+import org.sikuli.script.Pattern;
+
+public abstract class PatternAction implements IRecordedAction {
+  private Pattern pattern;
+
+  public PatternAction(Pattern pattern) {
+    super();
+    this.pattern = pattern;
+  }
+
+  public Pattern getPattern() {
+    return pattern;
+  }
+
+  public void setPattern(Pattern pattern) {
+    this.pattern = pattern;
+  }
+}

--- a/API/src/main/java/org/sikuli/script/support/recorder/actions/WaitAction.java
+++ b/API/src/main/java/org/sikuli/script/support/recorder/actions/WaitAction.java
@@ -7,19 +7,18 @@ package org.sikuli.script.support.recorder.actions;
 import org.sikuli.script.Pattern;
 import org.sikuli.script.support.generators.ICodeGenerator;
 
-public class WaitAction implements IRecordedAction {
-  private Pattern pattern;
+public class WaitAction extends PatternAction implements IRecordedAction {
   private Integer seconds;
   IRecordedAction matchAction;
 
   public WaitAction(Pattern pattern, Integer seconds, IRecordedAction matchAction) {
-    this.pattern = pattern;
+    super(pattern);
     this.seconds = seconds;
     this.matchAction = matchAction;
   }
 
   @Override
   public String generate(ICodeGenerator generator) {
-    return generator.wait(pattern, seconds, matchAction);
+    return generator.wait(getPattern(), seconds, matchAction);
   }
 }


### PR DESCRIPTION
This PR allows the recording of mouse wheel actions.

Additionally it was needed to straighten the Region class because there were many inconsistencies regarding available method parameters. For example it was not possible at all to use modifiers for wheel actions. And the click methods (click, doubleClick, rightClick) didn't allow to set the Modifiers as String (Key.CTRL + Key.SHIFT instead of KeyModifier.CTRL | KeyModifier.SHIFT).