### PR TITLE
Use a configurable resize factor instead of calculating it based on the screen resolution.

### DIFF
--- a/API/src/main/java/org/sikuli/script/Image.java
+++ b/API/src/main/java/org/sikuli/script/Image.java
@@ -54,6 +54,25 @@ public class Image {
     Debug.logx(level, me + message, args);
   }
 
+  /**
+   * Available resize interpolation algorithms
+   */
+  public enum Interpolation {
+    NEAREST(Imgproc.INTER_NEAREST),
+    LINEAR(Imgproc.INTER_LINEAR),
+    CUBIC(Imgproc.INTER_CUBIC),
+    AREA(Imgproc.INTER_AREA),
+    LANCZOS4(Imgproc.INTER_LANCZOS4),
+    LINEAR_EXACT(Imgproc.INTER_LINEAR_EXACT),
+    MAX(Imgproc.INTER_MAX);
+
+    private int value;
+
+    private Interpolation(int value) {
+      this.value = value;
+    }
+  }
+
   private static List<Image> images = Collections.synchronizedList(new ArrayList<Image>());
   private static Map<URL, Image> imageFiles = Collections.synchronizedMap(new HashMap<URL, Image>());
   private static Map<String, URL> imageNames = Collections.synchronizedMap(new HashMap<String, URL>());
@@ -373,42 +392,82 @@ public class Image {
   /**
    * resize the loaded image with factor using OpenCV ImgProc.resize()
    *
+   * Uses CUBIC as the interpolation algorithm.
+   *
    * @param factor resize factor
    * @return a new BufferedImage resized (width*factor, height*factor)
    */
   public BufferedImage resize(float factor) {
-    return resize(get(), factor);
+    return resize(factor, Interpolation.CUBIC);
+  }
+
+  /**
+   * resize the loaded image with factor using OpenCV ImgProc.resize()
+   *
+   * @param factor resize factor
+   * @param interpolation algorithm used for pixel interpolation
+   *
+   * @return a new BufferedImage resized (width*factor, height*factor)
+   */
+  public BufferedImage resize(float factor, Interpolation interpolation) {
+    return resize(get(), factor, interpolation);
+  }
+
+  /**
+   * resize the given image with factor using OpenCV ImgProc.resize()
+   *
+   * Uses CUBIC as the interpolation algorithm.
+   *
+   * @param factor resize factor
+   * @return a new BufferedImage resized (width*factor, height*factor)
+   */
+  public static BufferedImage resize(BufferedImage bimg, float factor) {
+    return resize(bimg, factor, Interpolation.CUBIC);
   }
 
   /**
    * resize the given image with factor using OpenCV ImgProc.resize()
    *
    * @param factor resize factor
+   * @param interpolation algorithm used for pixel interpolation
+   *
    * @return a new BufferedImage resized (width*factor, height*factor)
    */
-  public static BufferedImage resize(BufferedImage bimg, float factor) {
-    return Finder.Finder2.getBufferedImage(cvResize(bimg, factor));
+  public static BufferedImage resize(BufferedImage bimg, float factor, Interpolation interpolation) {
+    return Finder.Finder2.getBufferedImage(cvResize(bimg, factor, interpolation));
+  }
+
+  /**
+   * resize the given image (as cvMat in place) with factor using OpenCV ImgProc.resize()<br>
+   *
+   * Uses CUBIC as the interpolation algorithm.
+   *
+   * @param factor resize factor
+   */
+  public static void resize(Mat mat, float factor) {
+    resize(mat, factor, Interpolation.CUBIC);
   }
 
   /**
    * resize the given image (as cvMat in place) with factor using OpenCV ImgProc.resize()<br>
    *
    * @param factor resize factor
+   * @param interpolation algorithm used for pixel interpolation.
    */
-  public static void resize(Mat mat, float factor) {
-    cvResize(mat, factor);
+  public static void resize(Mat mat, float factor, Interpolation interpolation) {
+    cvResize(mat, factor, interpolation);
   }
 
-  private static Mat cvResize(BufferedImage bimg, double rFactor) {
+  private static Mat cvResize(BufferedImage bimg, double rFactor, Interpolation interpolation) {
     Mat mat = Finder.Finder2.makeMat(bimg);
-    cvResize(mat, rFactor);
+    cvResize(mat, rFactor, interpolation);
     return mat;
   }
 
-  private static void cvResize(Mat mat, double rFactor) {
+  private static void cvResize(Mat mat, double rFactor, Interpolation interpolation) {
     int newW = (int) (rFactor * mat.width());
     int newH = (int) (rFactor * mat.height());
-    Imgproc.resize(mat, mat, new Size(newW, newH), 0, 0, Imgproc.INTER_CUBIC);
+    Imgproc.resize(mat, mat, new Size(newW, newH), 0, 0, interpolation.value);
   }
 
   /**

--- a/API/src/main/java/org/sikuli/script/TextRecognizer.java
+++ b/API/src/main/java/org/sikuli/script/TextRecognizer.java
@@ -83,7 +83,7 @@ public class TextRecognizer {
   public static String versionTess4J = "4.4.1";
   public static String versionTesseract = "4.1.0";
 
-  private static final int TESSERACT_USER_DEFINED_DPI = 70;
+  private static final int TESSERACT_USER_DEFINED_DPI = 300;
 
   private TextRecognizer() {
     Finder.Finder2.init();
@@ -116,6 +116,9 @@ public class TextRecognizer {
    * text is between 20 and 30 px in the scaled image.
    */
   public float resizeFactor = 2.0f;
+
+
+  public Image.Interpolation resizeInterpolation = Image.Interpolation.LINEAR;
 
   private float factor() {
     // LEGACY: Calculate the resize factor based on the optimal and
@@ -181,8 +184,8 @@ public class TextRecognizer {
     }
     textRecognizer.setLanguage(textRecognizer.language);
 
-    // Set user_defined_dpi to the Tesseract default to
-    // avoid getting an error message on STDERR.
+    // Set user_defined_dpi to something other than 70 to avoid
+    // getting an error message on STDERR about guessing the resolution.
     // Interestingly, setting this to whatever value between
     // 70 and 2400 seems to have no impact on accuracy.
     // Not with LSTM and not with the legacy model either.
@@ -410,7 +413,7 @@ public class TextRecognizer {
     float rFactor = factor();
 
     if (rFactor > 1) {
-      Image.resize(mimg, rFactor);
+      Image.resize(mimg, rFactor, resizeInterpolation);
     }
 
     // sharpen the enlarged image again


### PR DESCRIPTION
The longer I play around with Tesseract the more I have the impression that resizing based on the current screen resolution is not a good idea at all.

- With LSTM it seems to be VERY important that the height of an upper case letter is between 20 and 30 px (see [here](https://groups.google.com/forum/#!msg/tesseract-ocr/Wdh_JJwnw94/24JHDYQbBQAJ)). This is difficult to achieve with the current solution.
- With the current solution the same script behaves differently on systems with different screen resolutions.
- Setting user_defined_dpi has no effect at all on accuracy, so just setting it to 70 to avoid the error message seems to be good enough
- Using a resize factor makes it is easier to reason about the expected behavior.

This would mitigate issues like #278 and #246. I'm not sure if it also have negative impacts.
