### PR TITLE
Also resize OCR image if resize factor is smaller than 1

### DIFF
--- a/API/src/main/java/org/sikuli/script/TextRecognizer.java
+++ b/API/src/main/java/org/sikuli/script/TextRecognizer.java
@@ -100,7 +100,7 @@ public class TextRecognizer {
   }
 
   /**
-   * @deprecated Will be removed in future versions
+   * @deprecated Use Toolkit.getDefaultToolkit().getScreenResolution() directly.
    *
    * @return the current screen resolution in dots per inch
    */
@@ -447,7 +447,7 @@ public class TextRecognizer {
 
     float rFactor = factor();
 
-    if (rFactor > 1) {
+    if (rFactor != 1) {
       Image.resize(mimg, rFactor, resizeInterpolation);
     }
 


### PR DESCRIPTION
This is needed when the expected X height is greater than 30 px.