### PR TITLE
Simplify ocr

### DIFF
--- a/API/src/main/java/org/sikuli/script/OCR.java
+++ b/API/src/main/java/org/sikuli/script/OCR.java
@@ -68,11 +68,18 @@ public class OCR {
   public static final int PAGE_ITERATOR_LEVEL_LINE = 2;
   //</editor-fold>
 
-  //<editor-fold desc="05 options">
-  private static Options globalOptions = Options.options();
+  /*
+   * OCR can't be instantiated.
+   */
+  private OCR() {
+    throw new UnsupportedOperationException();
+  }
 
-  public static Options globalOptions() {
-    return globalOptions;
+  //<editor-fold desc="05 options">
+  private static Options options = Options.options();
+
+  public static Options options() {
+    return options;
   }
 
   public static class Options implements Cloneable {
@@ -291,7 +298,7 @@ public class OCR {
       return this;
     }
 
-    public Options setFontSize(int size) {
+    public Options fontSize(int size) {
       Graphics g = new BufferedImage(100, 100, BufferedImage.TYPE_INT_RGB).getGraphics();
       try {
         Font font = new Font(g.getFont().getFontName(), 0, size);
@@ -413,7 +420,7 @@ public class OCR {
    * @return
    */
   public static Options reset() {
-    return OCR.globalOptions().reset();
+    return options().reset();
   }
 
   /**
@@ -421,7 +428,7 @@ public class OCR {
    * @return
    */
   public static void status() {
-    Debug.logp("Global settings " + OCR.globalOptions().toString());
+    Debug.logp("Global settings " + OCR.options().toString());
   }
   //</editor-fold>
 
@@ -436,7 +443,7 @@ public class OCR {
    * @return text
    */
   public static <SFIRBS> String readText(SFIRBS from) {
-    return readText(from, globalOptions());
+    return readText(from, options());
   }
 
   /**
@@ -465,7 +472,7 @@ public class OCR {
    * @return text
    */
   public static <SFIRBS> String readLine(SFIRBS from) {
-    return readLine(from, globalOptions());
+    return readLine(from, options());
   }
 
   /**
@@ -488,7 +495,7 @@ public class OCR {
    * @return lines
    */
   public static <SFIRBS> List<Match> readLines(SFIRBS from) {
-    return readLines(from, globalOptions());
+    return readLines(from, options());
   }
 
   /**
@@ -516,7 +523,7 @@ public class OCR {
    * @return text
    */
   public static <SFIRBS> String readWord(SFIRBS from) {
-    return readWord(from, globalOptions());
+    return readWord(from, options());
   }
 
   /**
@@ -539,7 +546,7 @@ public class OCR {
    * @return words
    */
   public static <SFIRBS> List<Match> readWords(SFIRBS from) {
-    return readWords(from, OCR.globalOptions());
+    return readWords(from, OCR.options());
   }
 
   /**
@@ -567,7 +574,7 @@ public class OCR {
    * @return text
    */
   public static <SFIRBS> String readChar(SFIRBS from) {
-    return readChar(from, globalOptions());
+    return readChar(from, options());
   }
 
   /**

--- a/API/src/main/java/org/sikuli/script/OCR.java
+++ b/API/src/main/java/org/sikuli/script/OCR.java
@@ -11,6 +11,8 @@ import java.util.List;
 
 /**
  * Static helper class for OCR.
+ * 
+ * The methods in this class are not threadsafe.
  */
 
 public class OCR {

--- a/API/src/main/java/org/sikuli/script/OCR.java
+++ b/API/src/main/java/org/sikuli/script/OCR.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 /**
  * Static helper class for OCR.
- * 
+ *
  * The methods in this class are not threadsafe.
  */
 
@@ -78,10 +78,10 @@ public class OCR {
   }
 
   //<editor-fold desc="05 options">
-  private static Options options = Options.options();
+  private static Options defaultOptions = new Options();
 
-  public static Options options() {
-    return options;
+  public static Options defaultOptions() {
+    return defaultOptions;
   }
 
   public static class Options implements Cloneable {
@@ -103,10 +103,6 @@ public class OCR {
 
     public Options() {
       reset();
-    }
-
-    public static Options options() {
-      return new Options();
     }
 
     public void validate() {
@@ -422,7 +418,7 @@ public class OCR {
    * @return
    */
   public static Options reset() {
-    return options().reset();
+    return defaultOptions().reset();
   }
 
   /**
@@ -430,7 +426,7 @@ public class OCR {
    * @return
    */
   public static void status() {
-    Debug.logp("Global settings " + OCR.options().toString());
+    Debug.logp("Global settings " + OCR.defaultOptions().toString());
   }
   //</editor-fold>
 
@@ -445,7 +441,7 @@ public class OCR {
    * @return text
    */
   public static <SFIRBS> String readText(SFIRBS from) {
-    return readText(from, options());
+    return readText(from, defaultOptions());
   }
 
   /**
@@ -474,7 +470,7 @@ public class OCR {
    * @return text
    */
   public static <SFIRBS> String readLine(SFIRBS from) {
-    return readLine(from, options());
+    return readLine(from, defaultOptions());
   }
 
   /**
@@ -497,7 +493,7 @@ public class OCR {
    * @return lines
    */
   public static <SFIRBS> List<Match> readLines(SFIRBS from) {
-    return readLines(from, options());
+    return readLines(from, defaultOptions());
   }
 
   /**
@@ -525,7 +521,7 @@ public class OCR {
    * @return text
    */
   public static <SFIRBS> String readWord(SFIRBS from) {
-    return readWord(from, options());
+    return readWord(from, defaultOptions());
   }
 
   /**
@@ -548,7 +544,7 @@ public class OCR {
    * @return words
    */
   public static <SFIRBS> List<Match> readWords(SFIRBS from) {
-    return readWords(from, OCR.options());
+    return readWords(from, OCR.defaultOptions());
   }
 
   /**
@@ -576,7 +572,7 @@ public class OCR {
    * @return text
    */
   public static <SFIRBS> String readChar(SFIRBS from) {
-    return readChar(from, options());
+    return readChar(from, defaultOptions());
   }
 
   /**

--- a/API/src/main/java/org/sikuli/script/TextRecognizer.java
+++ b/API/src/main/java/org/sikuli/script/TextRecognizer.java
@@ -43,9 +43,6 @@ public class TextRecognizer {
   private OCR.Options options;
 
   //<editor-fold desc="00 start, stop, reset">
-  private TextRecognizer() {
-    this(OCR.options());
-  }
 
   private TextRecognizer(OCR.Options options) {
     RunTime.loadLibrary(RunTime.libOpenCV);

--- a/API/src/main/java/org/sikuli/script/TextRecognizer.java
+++ b/API/src/main/java/org/sikuli/script/TextRecognizer.java
@@ -57,7 +57,7 @@ public class TextRecognizer {
    */
   @Deprecated
   public static TextRecognizer start() {
-    return get(OCR.options());
+    return get(OCR.defaultOptions());
   }
 
   protected static TextRecognizer get(OCR.Options options) {
@@ -65,7 +65,7 @@ public class TextRecognizer {
 
     Debug.log(lvl, "OCR: start: Tess4J %s using Tesseract %s", versionTess4J, versionTesseract);
     if (options == null) {
-      options = OCR.options();
+      options = OCR.defaultOptions();
     }
 
     return new TextRecognizer(options);
@@ -105,11 +105,11 @@ public class TextRecognizer {
    *
    * @param oem
    * @return
-   * @deprecated Use OCR.options().oem(OCR.OcrEngineMode oem)
+   * @deprecated Use OCR.defaultOptions().oem(OCR.OcrEngineMode oem)
    */
   @Deprecated
   public TextRecognizer setOEM(OCR.OcrEngineMode oem) {
-    OCR.options().oem(oem);
+    OCR.defaultOptions().oem(oem);
     return this;
   }
 
@@ -124,11 +124,11 @@ public class TextRecognizer {
    *
    * @param oem
    * @return
-   * @deprecated Use OCR.options().oem(int oem)
+   * @deprecated Use OCR.defaultOptions().oem(int oem)
    */
   @Deprecated
   public TextRecognizer setOEM(int oem) {
-    OCR.options().oem(oem);
+    OCR.defaultOptions().oem(oem);
     return this;
   }
 
@@ -138,11 +138,11 @@ public class TextRecognizer {
    *
    * @param psm
    * @return
-   * @deprecated Use OCR.options().psm(OCR.PageSegMode psm)
+   * @deprecated Use OCR.defaultOptions().psm(OCR.PageSegMode psm)
    */
   @Deprecated
   public TextRecognizer setPSM(OCR.PageSegMode psm) {
-    OCR.options().psm(psm);
+    OCR.defaultOptions().psm(psm);
     return this;
   }
 
@@ -167,11 +167,11 @@ public class TextRecognizer {
    *
    * @param psm
    * @return the textRecognizer instance
-   * @deprecated Use OCR.options().psm(int psm)
+   * @deprecated Use OCR.defaultOptions().psm(int psm)
    */
   @Deprecated
   public TextRecognizer setPSM(int psm) {
-    OCR.options().psm(psm);
+    OCR.defaultOptions().psm(psm);
     return this;
   }
   //</editor-fold>
@@ -183,11 +183,11 @@ public class TextRecognizer {
    *
    * @param dataPath
    * @return
-   * @deprecated Use OCR.options().datapath(String dataPath)
+   * @deprecated Use OCR.defaultOptions().datapath(String dataPath)
    */
   @Deprecated
   public TextRecognizer setDataPath(String dataPath) {
-    OCR.options().dataPath(dataPath);
+    OCR.defaultOptions().dataPath(dataPath);
     return this;
   }
 
@@ -196,11 +196,11 @@ public class TextRecognizer {
    *
    * @param language
    * @return
-   * @deprecated Use OCR.options().language(String language)
+   * @deprecated Use OCR.defaultOptions().language(String language)
    */
   @Deprecated
   public TextRecognizer setLanguage(String language) {
-    OCR.options().language(language);
+    OCR.defaultOptions().language(language);
     return this;
   }
 
@@ -210,11 +210,11 @@ public class TextRecognizer {
    * @param key
    * @param value
    * @return
-   * @deprecated Use OCR.options().variable(String key, String value)
+   * @deprecated Use OCR.defaultOptions().variable(String key, String value)
    */
   @Deprecated
   public TextRecognizer setVariable(String key, String value) {
-    OCR.options().variable(key, value);
+    OCR.defaultOptions().variable(key, value);
     return this;
   }
 
@@ -223,11 +223,11 @@ public class TextRecognizer {
    *
    * @param configs
    * @return
-   * @deprecated Use OCR.options.configs(String... configs)
+   * @deprecated Use OCR.defaultOptions().configs(String... configs)
    */
   @Deprecated
   public TextRecognizer setConfigs(String... configs) {
-    OCR.options().configs(Arrays.asList(configs));
+    OCR.defaultOptions().configs(Arrays.asList(configs));
     return this;
   }
 
@@ -236,11 +236,11 @@ public class TextRecognizer {
    *
    * @param configs
    * @return
-   * @deprecated Use OCR.options.configs(List<String> configs)
+   * @deprecated Use OCR.defaultOptions().configs(List<String> configs)
    */
   @Deprecated
   public TextRecognizer setConfigs(List<String> configs) {
-    OCR.options().configs(configs);
+    OCR.defaultOptions().configs(configs);
     return this;
   }
   //</editor-fold>

--- a/API/src/main/java/org/sikuli/script/TextRecognizer.java
+++ b/API/src/main/java/org/sikuli/script/TextRecognizer.java
@@ -43,11 +43,11 @@ public class TextRecognizer {
   private OCR.Options options;
 
   //<editor-fold desc="00 start, stop, reset">
-  protected TextRecognizer() {
-    this(OCR.globalOptions());
+  private TextRecognizer() {
+    this(OCR.options());
   }
 
-  protected TextRecognizer(OCR.Options options) {
+  private TextRecognizer(OCR.Options options) {
     RunTime.loadLibrary(RunTime.libOpenCV);
     options.validate();
     this.options = options;
@@ -60,7 +60,7 @@ public class TextRecognizer {
    */
   @Deprecated
   public static TextRecognizer start() {
-    return TextRecognizer.get(OCR.globalOptions());
+    return get(OCR.options());
   }
 
   protected static TextRecognizer get(OCR.Options options) {
@@ -68,7 +68,7 @@ public class TextRecognizer {
 
     Debug.log(lvl, "OCR: start: Tess4J %s using Tesseract %s", versionTess4J, versionTesseract);
     if (options == null) {
-      options = OCR.globalOptions();
+      options = OCR.options();
     }
 
     return new TextRecognizer(options);
@@ -82,7 +82,7 @@ public class TextRecognizer {
    */
   @Deprecated
   public static void reset() {
-    OCR.globalOptions().reset();
+    OCR.reset();
   }
 
   /**
@@ -92,16 +92,13 @@ public class TextRecognizer {
    */
   @Deprecated
   public static void status() {
-    Debug.logp("Global settings " + OCR.globalOptions().toString());
+    OCR.status();
   }
 
   public String toString() {
     return options.toString();
   }
 
-  public OCR.Options options() {
-    return options;
-  }
   //</editor-fold>
 
   //<editor-fold desc="02 set OEM, PSM">
@@ -111,11 +108,12 @@ public class TextRecognizer {
    *
    * @param oem
    * @return
-   * @deprecated Use options().oem()
+   * @deprecated Use OCR.options().oem(OCR.OcrEngineMode oem)
    */
   @Deprecated
   public TextRecognizer setOEM(OCR.OcrEngineMode oem) {
-    return setOEM(oem.ordinal());
+    OCR.options().oem(oem);
+    return this;
   }
 
   /**
@@ -129,11 +127,11 @@ public class TextRecognizer {
    *
    * @param oem
    * @return
-   * @deprecated Use options().oem()
+   * @deprecated Use OCR.options().oem(int oem)
    */
   @Deprecated
   public TextRecognizer setOEM(int oem) {
-    options().oem(oem);
+    OCR.options().oem(oem);
     return this;
   }
 
@@ -143,11 +141,12 @@ public class TextRecognizer {
    *
    * @param psm
    * @return
-   * @deprecated Use options().psm()
+   * @deprecated Use OCR.options().psm(OCR.PageSegMode psm)
    */
   @Deprecated
   public TextRecognizer setPSM(OCR.PageSegMode psm) {
-    return setPSM(psm.ordinal());
+    OCR.options().psm(psm);
+    return this;
   }
 
   /**
@@ -171,11 +170,11 @@ public class TextRecognizer {
    *
    * @param psm
    * @return the textRecognizer instance
-   * @deprecated Use options().psm()
+   * @deprecated Use OCR.options().psm(int psm)
    */
   @Deprecated
   public TextRecognizer setPSM(int psm) {
-    options().psm(psm);
+    OCR.options().psm(psm);
     return this;
   }
   //</editor-fold>
@@ -187,11 +186,11 @@ public class TextRecognizer {
    *
    * @param dataPath
    * @return
-   * @deprecated Use options().datapath()
+   * @deprecated Use OCR.options().datapath(String dataPath)
    */
   @Deprecated
   public TextRecognizer setDataPath(String dataPath) {
-    options().dataPath(dataPath);
+    OCR.options().dataPath(dataPath);
     return this;
   }
 
@@ -200,11 +199,11 @@ public class TextRecognizer {
    *
    * @param language
    * @return
-   * @deprecated Use options().language()
+   * @deprecated Use OCR.options().language(String language)
    */
   @Deprecated
   public TextRecognizer setLanguage(String language) {
-    options().language(language);
+    OCR.options().language(language);
     return this;
   }
 
@@ -214,11 +213,11 @@ public class TextRecognizer {
    * @param key
    * @param value
    * @return
-   * @deprecated Use options().variable(String key, String value)
+   * @deprecated Use OCR.options().variable(String key, String value)
    */
   @Deprecated
   public TextRecognizer setVariable(String key, String value) {
-    options().variable(key, value);
+    OCR.options().variable(key, value);
     return this;
   }
 
@@ -227,11 +226,11 @@ public class TextRecognizer {
    *
    * @param configs
    * @return
-   * @deprecated Use OCR.globalOptions.configs(String... configs)
+   * @deprecated Use OCR.options.configs(String... configs)
    */
   @Deprecated
   public TextRecognizer setConfigs(String... configs) {
-    setConfigs(Arrays.asList(configs));
+    OCR.options().configs(Arrays.asList(configs));
     return this;
   }
 
@@ -240,38 +239,16 @@ public class TextRecognizer {
    *
    * @param configs
    * @return
-   * @deprecated Use options.configs(List<String> configs)
+   * @deprecated Use OCR.options.configs(List<String> configs)
    */
   @Deprecated
   public TextRecognizer setConfigs(List<String> configs) {
-    options().configs(configs);
+    OCR.options().configs(configs);
     return this;
   }
   //</editor-fold>
 
   //<editor-fold desc="10 image optimization">
-
-  /**
-   * Hint for the OCR Engine about the expected font size in pt globally
-   *
-   * @param size expected font size in pt
-   * @deprecated Use options().setFontSize(int size)
-   */
-  public TextRecognizer setFontSize(int size) {
-    options().setFontSize(size);
-    return this;
-  }
-
-  /**
-   * Hint for the OCR Engine about the expected height of an uppercase X in px globally.
-   *
-   * @param height of an uppercase X in px
-   * @deprecated USe options().setTextHeight(int height)
-   */
-  public TextRecognizer setTextHeight(int height) {
-    options().textHeight(height);
-    return this;
-  }
 
   private BufferedImage optimize(BufferedImage bimg) {
     Mat mimg = Finder2.makeMat(bimg);
@@ -463,7 +440,7 @@ public class TextRecognizer {
   }
 
   /**
-   * use OCR.start() instead
+   * @deprecated use static OCR class instead
    *
    * @return
    */


### PR DESCRIPTION
Rename globalOption to options because its a static member anyway and hence clear that it is global. Also removes everything from TextRecognizer what is not strictly required for backwards compatibility. And make OCR non instantiable.