### PR TITLE
Fix target offset

### DIFF
--- a/API/src/main/java/org/sikuli/script/Element.java
+++ b/API/src/main/java/org/sikuli/script/Element.java
@@ -2427,6 +2427,11 @@ public abstract class Element {
       }
       break;
     }
+
+    if (match != null) {
+      match.setTargetOffset(image.offset());
+    }
+
     if (isOnScreen()) {
       if (!findAll && Settings.CheckLastSeen) {
         setMatchLastSeen(image, match);

--- a/API/src/main/java/org/sikuli/script/Pattern.java
+++ b/API/src/main/java/org/sikuli/script/Pattern.java
@@ -34,7 +34,7 @@ public class Pattern {
   }
 
   protected void copyAllAttributes(Pattern pattern) {
-    image = new Image(pattern.image);
+    image = new Image(pattern);
     similarity = pattern.similarity;
     offset.x = pattern.offset.x;
     offset.y = pattern.offset.y;
@@ -103,6 +103,7 @@ public class Pattern {
     if (this.image.sameSize(image)) {
       maskImage = image;
     }
+    image.mask(maskImage);
     return this;
   }
 
@@ -171,6 +172,7 @@ public class Pattern {
    */
   public Pattern similar(double sim) {
     similarity = sim;
+    image.similarity(similarity);
     return this;
   }
 
@@ -181,6 +183,7 @@ public class Pattern {
    */
   public Pattern exact() {
     similarity = 0.99;
+    image.similarity(similarity);
     return this;
   }
 
@@ -204,6 +207,7 @@ public class Pattern {
   public Pattern targetOffset(int dx, int dy) {
     offset.x = dx;
     offset.y = dy;
+    image.offset(offset);
     return this;
   }
 
@@ -216,6 +220,7 @@ public class Pattern {
   public Pattern targetOffset(Location loc) {
     offset.x = loc.x;
     offset.y = loc.y;
+    image.offset(offset);
     return this;
   }
 
@@ -246,6 +251,7 @@ public class Pattern {
    */
   public Pattern waitAfter(int waitAfter) {
     this.waitAfter = waitAfter;
+    image.waitAfter(waitAfter);
     return this;
   }
   //</editor-fold>


### PR DESCRIPTION
Target offset is broken in current master. E.g. click is always performed to the center.

First problem was, that the offset is not passed to the target image of the pattern. When we later get the image (in getLocationFromTarget()), the information is lost. Second problem was that the offset doesn't get passed to the resulting match.

This PR adds the missing functionality.