### PR TITLE
Fix lost key events

### DIFF
--- a/API/src/main/java/org/sikuli/natives/SXUser32.java
+++ b/API/src/main/java/org/sikuli/natives/SXUser32.java
@@ -15,10 +15,14 @@ public interface SXUser32 extends User32 {
   short GetKeyState(int vKey);
 
   int MapVirtualKeyExW (int uCode, int nMapType, int dwhkl);
+  
+  int MapVirtualKeyW(int uCode, int uMapType);
 
   boolean GetKeyboardState(byte[] lpKeyState);
 
   int ToUnicodeEx(int wVirtKey, int wScanCode, byte[] lpKeyState, char[] pwszBuff, int cchBuff, int wFlags, int dwhkl);
-
+  
+  void keybd_event(byte bVk, byte bScan, DWORD dwFlags, ULONG_PTR dwExtraInfo);
+  
 }
 

--- a/API/src/main/java/org/sikuli/script/support/RobotDesktop.java
+++ b/API/src/main/java/org/sikuli/script/support/RobotDesktop.java
@@ -30,7 +30,7 @@ public class RobotDesktop extends Robot implements IRobot {
 
   final static int MAX_DELAY = 60000;
   public static final int ALL_MODIFIERS = KeyModifier.SHIFT | KeyModifier.CTRL | KeyModifier.ALT |  KeyModifier.META | KeyModifier.ALTGR;
-  
+
   private static int heldButtons = 0;
   private static String heldKeys = "";
   private static final ArrayList<Integer> heldKeyCodes = new ArrayList<Integer>();
@@ -316,17 +316,6 @@ public class RobotDesktop extends Robot implements IRobot {
     // Since this layout is not compatible to AWT Robot, we have to use
     // the User32 API to simulate the key press
     if (Settings.AutoDetectKeyboardLayout && Settings.isWindows()) {
-//      WinUser.INPUT input = new WinUser.INPUT();
-//      input.type = new WinDef.DWORD(WinUser.INPUT.INPUT_KEYBOARD);
-//      input.input.setType("ki");
-//      input.input.ki.wScan = new WinDef.WORD(0);
-//      input.input.ki.time = new WinDef.DWORD(0);
-//      input.input.ki.dwExtraInfo = new BaseTSD.ULONG_PTR(0);
-//      input.input.ki.wVk = new WinDef.WORD(keyCode);
-//      input.input.ki.dwFlags = new WinDef.DWORD(0);
-//
-//      User32.INSTANCE.SendInput(new WinDef.DWORD(1),
-//          (WinUser.INPUT[]) input.toArray(1), input.size());
         int scanCode =  SXUser32.INSTANCE.MapVirtualKeyW(keyCode, 0);
         SXUser32.INSTANCE.keybd_event((byte)keyCode, (byte)scanCode, new WinDef.DWORD(0), new BaseTSD.ULONG_PTR(0));
     }else{
@@ -378,18 +367,6 @@ public class RobotDesktop extends Robot implements IRobot {
     // Since this layout is not compatible to AWT Robot, we have to use
     // the User32 API to simulate the key release
     if (Settings.AutoDetectKeyboardLayout && Settings.isWindows()) {
-//      WinUser.INPUT input = new WinUser.INPUT();
-//      input.type = new WinDef.DWORD(WinUser.INPUT.INPUT_KEYBOARD);
-//      input.input.setType("ki");
-//      input.input.ki.wScan = new WinDef.WORD(0);
-//      input.input.ki.time = new WinDef.DWORD(0);
-//      input.input.ki.dwExtraInfo = new BaseTSD.ULONG_PTR(0);
-//      input.input.ki.wVk = new WinDef.WORD(keyCode);
-//      input.input.ki.dwFlags = new WinDef.DWORD(
-//          WinUser.KEYBDINPUT.KEYEVENTF_KEYUP);
-//
-//      User32.INSTANCE.SendInput(new WinDef.DWORD(1),
-//          (WinUser.INPUT[]) input.toArray(1), input.size());
       int scanCode =  SXUser32.INSTANCE.MapVirtualKeyW(keyCode, 0);
       SXUser32.INSTANCE.keybd_event((byte)keyCode, (byte)scanCode, new WinDef.DWORD(WinUser.KEYBDINPUT.KEYEVENTF_KEYUP), new BaseTSD.ULONG_PTR(0));
     }else{

--- a/API/src/main/java/org/sikuli/script/support/RobotDesktop.java
+++ b/API/src/main/java/org/sikuli/script/support/RobotDesktop.java
@@ -7,6 +7,7 @@ import org.sikuli.basics.Animator;
 import org.sikuli.basics.AnimatorOutQuarticEase;
 import org.sikuli.basics.AnimatorTimeBased;
 import org.sikuli.basics.Settings;
+import org.sikuli.natives.SXUser32;
 import org.sikuli.basics.Debug;
 
 import com.sun.jna.platform.win32.BaseTSD;
@@ -315,17 +316,19 @@ public class RobotDesktop extends Robot implements IRobot {
     // Since this layout is not compatible to AWT Robot, we have to use
     // the User32 API to simulate the key press
     if (Settings.AutoDetectKeyboardLayout && Settings.isWindows()) {
-      WinUser.INPUT input = new WinUser.INPUT();
-      input.type = new WinDef.DWORD(WinUser.INPUT.INPUT_KEYBOARD);
-      input.input.setType("ki");
-      input.input.ki.wScan = new WinDef.WORD(0);
-      input.input.ki.time = new WinDef.DWORD(0);
-      input.input.ki.dwExtraInfo = new BaseTSD.ULONG_PTR(0);
-      input.input.ki.wVk = new WinDef.WORD(keyCode);
-      input.input.ki.dwFlags = new WinDef.DWORD(0);
-
-      User32.INSTANCE.SendInput(new WinDef.DWORD(1),
-          (WinUser.INPUT[]) input.toArray(1), input.size());
+//      WinUser.INPUT input = new WinUser.INPUT();
+//      input.type = new WinDef.DWORD(WinUser.INPUT.INPUT_KEYBOARD);
+//      input.input.setType("ki");
+//      input.input.ki.wScan = new WinDef.WORD(0);
+//      input.input.ki.time = new WinDef.DWORD(0);
+//      input.input.ki.dwExtraInfo = new BaseTSD.ULONG_PTR(0);
+//      input.input.ki.wVk = new WinDef.WORD(keyCode);
+//      input.input.ki.dwFlags = new WinDef.DWORD(0);
+//
+//      User32.INSTANCE.SendInput(new WinDef.DWORD(1),
+//          (WinUser.INPUT[]) input.toArray(1), input.size());
+        int scanCode =  SXUser32.INSTANCE.MapVirtualKeyW(keyCode, 0);
+        SXUser32.INSTANCE.keybd_event((byte)keyCode, (byte)scanCode, new WinDef.DWORD(0), new BaseTSD.ULONG_PTR(0));
     }else{
       keyPress(keyCode);
     }
@@ -375,18 +378,20 @@ public class RobotDesktop extends Robot implements IRobot {
     // Since this layout is not compatible to AWT Robot, we have to use
     // the User32 API to simulate the key release
     if (Settings.AutoDetectKeyboardLayout && Settings.isWindows()) {
-      WinUser.INPUT input = new WinUser.INPUT();
-      input.type = new WinDef.DWORD(WinUser.INPUT.INPUT_KEYBOARD);
-      input.input.setType("ki");
-      input.input.ki.wScan = new WinDef.WORD(0);
-      input.input.ki.time = new WinDef.DWORD(0);
-      input.input.ki.dwExtraInfo = new BaseTSD.ULONG_PTR(0);
-      input.input.ki.wVk = new WinDef.WORD(keyCode);
-      input.input.ki.dwFlags = new WinDef.DWORD(
-          WinUser.KEYBDINPUT.KEYEVENTF_KEYUP);
-
-      User32.INSTANCE.SendInput(new WinDef.DWORD(1),
-          (WinUser.INPUT[]) input.toArray(1), input.size());
+//      WinUser.INPUT input = new WinUser.INPUT();
+//      input.type = new WinDef.DWORD(WinUser.INPUT.INPUT_KEYBOARD);
+//      input.input.setType("ki");
+//      input.input.ki.wScan = new WinDef.WORD(0);
+//      input.input.ki.time = new WinDef.DWORD(0);
+//      input.input.ki.dwExtraInfo = new BaseTSD.ULONG_PTR(0);
+//      input.input.ki.wVk = new WinDef.WORD(keyCode);
+//      input.input.ki.dwFlags = new WinDef.DWORD(
+//          WinUser.KEYBDINPUT.KEYEVENTF_KEYUP);
+//
+//      User32.INSTANCE.SendInput(new WinDef.DWORD(1),
+//          (WinUser.INPUT[]) input.toArray(1), input.size());
+      int scanCode =  SXUser32.INSTANCE.MapVirtualKeyW(keyCode, 0);
+      SXUser32.INSTANCE.keybd_event((byte)keyCode, (byte)scanCode, new WinDef.DWORD(WinUser.KEYBDINPUT.KEYEVENTF_KEYUP), new BaseTSD.ULONG_PTR(0));
     }else{
       keyRelease(keyCode);
     }


### PR DESCRIPTION
Use `keybd_event` instead of  `SendInput`. Works much better on our side in some use cases. AWT Robot is also doing it exactly this way (https://github.com/frohoff/jdk8u-jdk/blob/da0da73ab82ed714dc5be94acd2f0d00fbdfe2e9/src/windows/native/sun/windows/awt_Robot.cpp#L317).