### PR TITLE
fix: improve Element.log performance

### DIFF
--- a/API/src/main/java/org/sikuli/script/Element.java
+++ b/API/src/main/java/org/sikuli/script/Element.java
@@ -39,6 +39,9 @@ public abstract class Element {
   static final int logLevel = 3;
 
   static void log(int level, String message, Object... args) {
+    if (!Debug.is(level)) {
+      return;
+    }
     String className = Thread.currentThread().getStackTrace()[2].getClassName();
     String caller = className.substring(className.lastIndexOf(".") + 1);
     Debug.logx(level, caller + ": " + message, args);


### PR DESCRIPTION
call getStackTrace and logx only if the level <= DEBUG_LEVEL

furthermore we should using logging system (such slf4j-api + log4j2 or logback)

ref: #361