### PR TITLE
Fix bundle path handling when run with -r option

### DIFF
--- a/API/src/main/java/org/sikuli/script/runners/AbstractLocalFileScriptRunner.java
+++ b/API/src/main/java/org/sikuli/script/runners/AbstractLocalFileScriptRunner.java
@@ -20,7 +20,10 @@ public abstract class AbstractLocalFileScriptRunner extends AbstractScriptRunner
 		File file = new File(script);
 
 		if (file.exists()) {
-			PREVIOUS_BUNDLE_PATHS.push(ImagePath.getBundlePath());
+			String currentBundlePath = ImagePath.getBundlePath();
+			if(currentBundlePath != null) {
+			  PREVIOUS_BUNDLE_PATHS.push(currentBundlePath);
+			}
 			ImagePath.setBundleFolder(file.getParentFile());
 		}
 	}


### PR DESCRIPTION
Sikulix failed with -r option (NullPointerException) because there is no image path before the first script run. Previously I only tested the stuff from the IDE where the image path is always there. Now the existence of the current image path is tested, if not there it is not added to the Deque.