### PR TITLE
Exclude log4j and commons-logging as we have slf4j logging bridges al…

### DIFF
--- a/API/pom.xml
+++ b/API/pom.xml
@@ -141,6 +141,14 @@
           <groupId>net.java.dev.jna</groupId>
           <artifactId>jna</artifactId>
         </exclusion>
+        <exclusion><!-- we have log4j-over-slf4j, it conflicts with real log4j -->
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion><!-- we have jcl-over-slf4j, it conflicts with real commons-logging -->
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
Hi,

This is a fix for https://github.com/RaiMan/SikuliX1/issues/412

This seems to be due to a mess in tess4j v4.4.1. It includes both original loggers and slf4j bridges.

tess4j version 4.5.4 still has original loggers, but no slf4j bridges... Which means if you upgrade tess4j, you might need to either add slf4j bridges or remove those exclusions.

Anyway, this is sufficient to get my stuff working. I was actually able to get this project working by adding explicit exclusions in my own dependencies, but it's a hassle and it's better fixed in upstream SikuliX1 which is why I reported it. Anyway, no rush to release it.

Thanks for your attention,
Sincerely,
Teofilis Martisius