### PR TITLE
Providing a different path to users with a M1 MacBook

### DIFF
--- a/API/src/main/java/org/sikuli/script/TextRecognizer.java
+++ b/API/src/main/java/org/sikuli/script/TextRecognizer.java
@@ -68,12 +68,17 @@ public class TextRecognizer {
     if (!isValid) {
       //TODO Tess4J: macOS: tesseract library load problem
       if (Commons.runningMac()) {
-        String libPath = "/usr/local/lib";
+          String libPath = "/usr/local/lib";
+          // MacM1 needs a different path of tesseract
+        if(Commons.getOSArch() == "aarch64") {
+           libPath = "/opt/homebrew";
+        }
+
         File libTess = new File(libPath, "libtesseract.dylib");
         if (libTess.exists()) {
           Commons.jnaPathAdd(libPath);
         } else {
-          throw new SikuliXception(String.format("OCR: validate: libtesseract.dylib not in /usr/local/lib"));
+          throw new SikuliXception(String.format("OCR: validate: libtesseract.dylib not in "+ libPath));
         }
       }
       Commons.loadOpenCV();

--- a/API/src/main/java/org/sikuli/support/Commons.java
+++ b/API/src/main/java/org/sikuli/support/Commons.java
@@ -51,6 +51,7 @@ public class Commons {
 
   private static final String osName = System.getProperty("os.name").toLowerCase();
   private static final String osVersion = System.getProperty("os.version").toLowerCase();
+  private static final String osArch = System.getProperty("os.arch").toLowerCase();
 
   private static final String sxTempDir = System.getProperty("java.io.tmpdir");
   private static File sxTempFolder = null;
@@ -555,6 +556,11 @@ public class Commons {
 
   public static String getOSVersion() {
     return osVersion;
+  }
+
+
+  public static String getOSArch() {
+    return osArch;
   }
 
   public static String getOSInfo() {


### PR DESCRIPTION
Trying to fix issue #453.
The default installation folder of tesseract on a MacBook M1 is /opt/homebrew. 