### PR TITLE
Update README.md - add paul-hammant's example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ For use in **Java Maven projects** the dependency coordinates are:
   <version>2.0.5</version>
 </dependency>
 ```
+
+For a headstart you can download paul-hammant's [MySikuliExample](https://github.com/paul-hammant/MySikuliExample).
+
 <hr>
 
 **My Development environment**


### PR DESCRIPTION
I suggest to add paul-hammant's [MySikuliExample](https://github.com/paul-hammant/MySikuliExample) to the README.md.

- It is updated to the latest Sikuli version, 2.0.5.
- It is a Maven project that only depends on Sikuli and JUnit.
- It runs on Mac and Windows.
- It is IDE agnostic.
- Duck.ai suggests it when searching for "Sikuli, Maven, JUnit".
  <img width="400" height="549" alt="Image" src="https://github.com/user-attachments/assets/d5a5c7ae-4d85-423f-a844-0d0052811c1c" />
- It appears at 33rd place when I search GitHub for "Sikuli". Every other example at a higher place depends on a language binding, another framework, or other installed software.

